### PR TITLE
feat: engagement dashboard + captain engagement mobile parity

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -89,6 +89,7 @@ function getDrawerNavSections(
       { label: 'Approve Donations', icon: 'heart', route: 'rest-day-donations' },
       { label: 'Team Chat', icon: 'message-circle', route: '(tabs)/team-chat' },
       { label: 'AI Manager', icon: 'cpu', route: 'ai-manager' },
+      { label: 'Engagement', icon: 'trending-up', route: 'engagement-dashboard' },
       { label: 'AI Usage', icon: 'activity', route: 'ai-usage' },
       { label: 'Manage Sponsors', icon: 'speaker', route: 'sponsors' },
     );
@@ -106,6 +107,7 @@ function getDrawerNavSections(
       items: [
         { label: 'Team Overview', icon: 'users', route: '(tabs)/my-team' },
         { label: 'Team Activities', icon: 'clipboard', route: 'submission-validation' },
+        { label: 'Captain Engagement', icon: 'shield', route: 'captain-engagement' },
         { label: 'Approve Donations', icon: 'heart', route: 'rest-day-donations' },
       ],
     });
@@ -405,6 +407,8 @@ export default function AppLayout() {
           <Stack.Screen name="quick-start-league" />
           <Stack.Screen name="sponsors" />
           <Stack.Screen name="wearables" />
+          <Stack.Screen name="engagement-dashboard" />
+          <Stack.Screen name="captain-engagement" />
         </Stack>
       </DrawerLayout>
     </DrawerContext.Provider>

--- a/src/app/(app)/captain-engagement.tsx
+++ b/src/app/(app)/captain-engagement.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useState } from 'react';
+import { View, ScrollView, RefreshControl, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Card } from 'heroui-native';
+import Feather from '@expo/vector-icons/Feather';
+import { AppText } from '../../components/app-text';
+import { DarkHeaderCard } from '../../components/dark-header-card';
+import { SectionLabel } from '../../components/section-label';
+import { ScreenState } from '../../components/screen-state';
+import { useLeagueContext } from '../../contexts/league-context';
+import { useRole } from '../../contexts/role-context';
+import { mflColors } from '../../constants/colors';
+import type { MilestoneDraft } from '../../features/captain-engagement/types/captain-engagement.model';
+import {
+  useCaptainAtRisk,
+  useMilestoneDrafts,
+  useEditMilestoneDraft,
+  useSendMilestoneDraft,
+  CaptainAtRiskFeed,
+  MilestoneDraftCard,
+} from '../../features/captain-engagement';
+
+export default function CaptainEngagementScreen() {
+  const insets = useSafeAreaInsets();
+  const { activeLeague } = useLeagueContext();
+  const { isCaptain, isHost, isGovernor } = useRole();
+  const leagueId = activeLeague?.leagueId ?? '';
+
+  if (!isCaptain && !isHost && !isGovernor) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState
+          state="empty"
+          message="Captain Engagement is available to captains, hosts, and governors."
+        />
+      </View>
+    );
+  }
+
+  if (!activeLeague) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState state="empty" message="Select a league first" />
+      </View>
+    );
+  }
+
+  return <CaptainEngagementContent leagueId={leagueId} />;
+}
+
+function CaptainEngagementContent({ leagueId }: { leagueId: string }) {
+  const insets = useSafeAreaInsets();
+  const atRiskQ = useCaptainAtRisk(leagueId);
+  const draftsQ = useMilestoneDrafts(leagueId);
+  const editMutation = useEditMilestoneDraft(leagueId);
+  const sendMutation = useSendMilestoneDraft(leagueId);
+
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.all([atRiskQ.refetch(), draftsQ.refetch()]);
+    setRefreshing(false);
+  }, [atRiskQ, draftsQ]);
+
+  const handleSaveDraft = (draftId: string, content: string) => {
+    editMutation.mutate(
+      { draftId, content },
+      {
+        onSuccess: () => Alert.alert('Saved', 'Draft saved.'),
+        onError: () => Alert.alert('Error', 'Failed to save draft'),
+      },
+    );
+  };
+
+  const handleSendDraft = (draftId: string) => {
+    sendMutation.mutate(draftId, {
+      onSuccess: () => Alert.alert('Sent', 'Message sent!'),
+      onError: () => Alert.alert('Error', 'Failed to send message'),
+    });
+  };
+
+  const atRiskPlayers = atRiskQ.data ?? [];
+  const drafts = draftsQ.data ?? [];
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      style={{ paddingTop: insets.top }}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 20 }}
+      showsVerticalScrollIndicator={false}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      {/* Header */}
+      <DarkHeaderCard
+        title="Captain Engagement"
+        subtitle="Review at-risk teammates and send milestone messages"
+        style={{ marginTop: 12, marginBottom: 16 }}
+      />
+
+      {/* At-Risk Section */}
+      <View className="mb-6">
+        <View className="flex-row items-center gap-2 mb-2">
+          <Feather name="alert-triangle" size={16} color={mflColors.amber} />
+          <SectionLabel label="At-Risk Players" />
+        </View>
+        <CaptainAtRiskFeed
+          players={atRiskPlayers}
+          isLoading={atRiskQ.isLoading}
+          error={atRiskQ.isError ? 'Failed to load at-risk players' : null}
+        />
+      </View>
+
+      {/* Milestone Drafts Section */}
+      <View className="mb-4">
+        <View className="flex-row items-center gap-2 mb-2">
+          <Feather name="message-square" size={16} color={mflColors.brand} />
+          <SectionLabel label="Milestone Messages" />
+          {drafts.length > 0 && (
+            <View className="rounded-full px-2 py-0.5 ml-auto" style={{ backgroundColor: mflColors.inkLight }}>
+              <AppText className="text-[10px] font-bold text-muted">{drafts.length}</AppText>
+            </View>
+          )}
+        </View>
+
+        {draftsQ.isLoading ? (
+          <Card className="p-4">
+            <AppText className="text-xs text-muted text-center">Loading milestone drafts...</AppText>
+          </Card>
+        ) : drafts.length === 0 ? (
+          <Card className="p-4">
+            <AppText className="text-xs text-muted text-center">No milestone drafts right now.</AppText>
+          </Card>
+        ) : (
+          drafts.map((draft: MilestoneDraft) => (
+            <MilestoneDraftCard
+              key={draft.id}
+              draft={draft}
+              onSave={handleSaveDraft}
+              onSend={handleSendDraft}
+              isSaving={!!(editMutation.isPending && editMutation.variables?.draftId === draft.id)}
+              isSending={!!(sendMutation.isPending && sendMutation.variables === draft.id)}
+            />
+          ))
+        )}
+      </View>
+    </ScrollView>
+  );
+}

--- a/src/app/(app)/engagement-dashboard.tsx
+++ b/src/app/(app)/engagement-dashboard.tsx
@@ -1,0 +1,167 @@
+import { View, ScrollView, RefreshControl } from 'react-native';
+import { useCallback, useState } from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { AppText } from '../../components/app-text';
+import { DarkHeaderCard } from '../../components/dark-header-card';
+import { ScreenState } from '../../components/screen-state';
+import { useLeagueContext } from '../../contexts/league-context';
+import { useRole } from '../../contexts/role-context';
+import { mflColors } from '../../constants/colors';
+import {
+  useEngagement,
+  MetricCard,
+  DailyActiveChart,
+  EventBreakdown,
+  StreakDistribution,
+  AtRiskList,
+  TopEngagers,
+} from '../../features/engagement';
+
+export default function EngagementDashboardScreen() {
+  const insets = useSafeAreaInsets();
+  const { activeLeague } = useLeagueContext();
+  const { isHost, isGovernor } = useRole();
+  const leagueId = activeLeague?.leagueId ?? '';
+
+  // RBAC guard — host/governor only
+  if (!isHost && !isGovernor) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState
+          screen="governor"
+          state="empty"
+          message="Engagement Dashboard is only available to hosts and governors."
+        />
+      </View>
+    );
+  }
+
+  if (!activeLeague) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState
+          screen="governor"
+          state="empty"
+          message="Select a league to view the Engagement Dashboard"
+        />
+      </View>
+    );
+  }
+
+  return <EngagementContent leagueId={leagueId} />;
+}
+
+function EngagementContent({ leagueId }: { leagueId: string }) {
+  const insets = useSafeAreaInsets();
+  const { isHost } = useRole();
+  const { data, isLoading, isError, refetch } = useEngagement(leagueId);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  }, [refetch]);
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState state="loading" />
+      </View>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}>
+        <ScreenState
+          state="error"
+          message="Failed to load engagement data"
+          actionLabel="Retry"
+          onAction={() => refetch()}
+        />
+      </View>
+    );
+  }
+
+  const totalEvents = data.eventBreakdown.reduce((s: number, e: { count: number }) => s + e.count, 0);
+
+  const participationColor =
+    data.participationRate >= 70
+      ? mflColors.brand
+      : data.participationRate >= 40
+        ? mflColors.amber
+        : mflColors.danger;
+
+  return (
+    <ScrollView
+      className="flex-1 bg-background"
+      style={{ paddingTop: insets.top }}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 20 }}
+      showsVerticalScrollIndicator={false}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      {/* Header */}
+      <DarkHeaderCard
+        title="Engagement Dashboard"
+        subtitle={isHost ? 'Host View' : 'Governor View'}
+        style={{ marginTop: 12, marginBottom: 16 }}
+      />
+
+      {/* 4 Metric Cards — 2x2 grid */}
+      <View className="flex-row gap-3 mb-3">
+        <MetricCard
+          label="Participation"
+          value={`${data.participationRate}%`}
+          color={participationColor}
+        />
+        <MetricCard
+          label="Active (7d)"
+          value={String(data.activeUsersLast7Days)}
+          color="#3B82F6"
+          subtitle={`/ ${data.totalMembers}`}
+        />
+      </View>
+      <View className="flex-row gap-3 mb-4">
+        <MetricCard
+          label="At Risk"
+          value={String(data.atRiskPlayers.length)}
+          color={data.atRiskPlayers.length > 0 ? mflColors.danger : mflColors.brand}
+        />
+        <MetricCard
+          label="Events (30d)"
+          value={String(totalEvents)}
+          color="#A855F7"
+        />
+      </View>
+
+      {/* Daily Active Users Chart */}
+      <View className="mb-4">
+        <DailyActiveChart data={data.dailyActiveUsers} />
+      </View>
+
+      {/* Event Breakdown + Streak Distribution */}
+      <View className="mb-4">
+        <EventBreakdown items={data.eventBreakdown} />
+      </View>
+      <View className="mb-4">
+        <StreakDistribution buckets={data.streakDistribution} />
+      </View>
+
+      {/* At-Risk Players */}
+      <View className="mb-4">
+        <AtRiskList players={data.atRiskPlayers} />
+      </View>
+
+      {/* Top Engagers */}
+      <View className="mb-4">
+        <TopEngagers engagers={data.topEngagers} />
+      </View>
+
+      {/* Footer */}
+      <AppText className="text-[10px] text-muted text-center mt-2">
+        Last updated: {new Date(data.exportedAt).toLocaleString()}
+      </AppText>
+    </ScrollView>
+  );
+}

--- a/src/core/config/query-keys.ts
+++ b/src/core/config/query-keys.ts
@@ -43,6 +43,9 @@ export const queryKeys = {
     sponsors: (id: string) => [...queryKeys.leagues.all, id, 'sponsors'] as const,
     wearableConnections: (id: string) => [...queryKeys.leagues.all, id, 'wearable-connections'] as const,
     pendingConfirmations: (id: string) => [...queryKeys.leagues.all, id, 'pending-confirmations'] as const,
+    engagement: (id: string) => [...queryKeys.leagues.all, id, 'engagement'] as const,
+    captainAtRisk: (id: string) => [...queryKeys.leagues.all, id, 'captain-at-risk'] as const,
+    milestoneDrafts: (id: string) => [...queryKeys.leagues.all, id, 'milestone-drafts'] as const,
   },
   dashboard: {
     all: ['dashboard'] as const,

--- a/src/features/captain-engagement/components/captain-at-risk-feed.tsx
+++ b/src/features/captain-engagement/components/captain-at-risk-feed.tsx
@@ -1,0 +1,81 @@
+import { View } from 'react-native';
+import { Card, Spinner } from 'heroui-native';
+import Feather from '@expo/vector-icons/Feather';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { CaptainAtRiskPlayer } from '../types/captain-engagement.model';
+
+interface CaptainAtRiskFeedProps {
+  players: CaptainAtRiskPlayer[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function CaptainAtRiskFeed({ players, isLoading, error }: CaptainAtRiskFeedProps) {
+  if (isLoading) {
+    return (
+      <View className="flex-row items-center gap-2 py-6">
+        <Spinner size="sm" />
+        <AppText className="text-xs text-muted">Loading at-risk players...</AppText>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-4">
+        <View className="flex-row items-center gap-2">
+          <Feather name="alert-triangle" size={14} color={mflColors.danger} />
+          <AppText className="text-xs" style={{ color: mflColors.danger }}>{error}</AppText>
+        </View>
+      </Card>
+    );
+  }
+
+  if (players.length === 0) {
+    return (
+      <Card className="p-4">
+        <View className="flex-row items-center gap-2">
+          <Feather name="trending-down" size={14} color={mflColors.textMuted} />
+          <AppText className="text-xs text-muted">No at-risk players right now.</AppText>
+        </View>
+      </Card>
+    );
+  }
+
+  return (
+    <View>
+      {players.map((player) => (
+        <Card key={player.userId} className="p-3 mb-2">
+          <View className="flex-row items-start justify-between mb-1">
+            <AppText className="text-sm font-semibold text-foreground">{player.username}</AppText>
+            <View
+              className="rounded-full px-2 py-0.5"
+              style={{
+                backgroundColor: player.reason === 'inactive_48h' ? mflColors.dangerLight : mflColors.inkLight,
+              }}
+            >
+              <AppText
+                className="text-[10px] font-bold"
+                style={{
+                  color: player.reason === 'inactive_48h' ? mflColors.danger : mflColors.textSub,
+                }}
+              >
+                {player.reason === 'inactive_48h' ? 'Inactive 48h' : 'Below Avg'}
+              </AppText>
+            </View>
+          </View>
+          <View className="flex-row items-center gap-2">
+            <Feather name="alert-circle" size={12} color={mflColors.amber} />
+            <AppText className="text-xs text-foreground">
+              Last active: {player.lastSubmissionAt || 'Never'}
+            </AppText>
+          </View>
+          <AppText className="text-[11px] text-muted mt-0.5">
+            Player activity: {Math.round(player.playerActivity)} · Team average: {Math.round(player.teamAverage)}
+          </AppText>
+        </Card>
+      ))}
+    </View>
+  );
+}

--- a/src/features/captain-engagement/components/milestone-draft-card.tsx
+++ b/src/features/captain-engagement/components/milestone-draft-card.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { View, TextInput, Alert } from 'react-native';
+import { Card, Spinner, Button } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { MilestoneDraft } from '../types/captain-engagement.model';
+
+interface MilestoneDraftCardProps {
+  draft: MilestoneDraft;
+  onSave: (draftId: string, content: string) => void;
+  onSend: (draftId: string) => void;
+  isSaving: boolean;
+  isSending: boolean;
+}
+
+export function MilestoneDraftCard({
+  draft,
+  onSave,
+  onSend,
+  isSaving,
+  isSending,
+}: MilestoneDraftCardProps) {
+  const [content, setContent] = useState(draft.content);
+  const isModified = content !== draft.content;
+
+  return (
+    <Card className="p-4 mb-3">
+      {/* Header */}
+      <View className="flex-row items-center justify-between mb-2">
+        <AppText className="text-sm font-semibold text-foreground">
+          {draft.targetUsername}
+        </AppText>
+        <AppText className="text-[10px] text-muted capitalize">
+          {(draft.milestoneType ?? draft.type ?? 'milestone').replace(/_/g, ' ')}
+        </AppText>
+      </View>
+
+      {/* Editable content */}
+      <TextInput
+        className="bg-background rounded-lg p-3 text-sm text-foreground mb-3"
+        style={{
+          minHeight: 80,
+          textAlignVertical: 'top',
+          borderWidth: 1,
+          borderColor: mflColors.border,
+        }}
+        multiline
+        value={content}
+        onChangeText={setContent}
+        placeholder="Edit the draft message..."
+        placeholderTextColor={mflColors.textMuted}
+      />
+
+      {/* Action buttons */}
+      <View className="flex-row gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          className="flex-1"
+          onPress={() => onSave(draft.id, content)}
+          isDisabled={isSaving || isSending || !isModified}
+        >
+          {isSaving ? <Spinner size="sm" /> : <Button.Label>Save Draft</Button.Label>}
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          className="flex-1"
+          onPress={() => {
+            Alert.alert(
+              'Send Message',
+              `Send this message to ${draft.targetUsername}?`,
+              [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Send', onPress: () => onSend(draft.id) },
+              ],
+            );
+          }}
+          isDisabled={isSending}
+          style={{ backgroundColor: mflColors.brand }}
+        >
+          {isSending ? <Spinner size="sm" /> : <Button.Label style={{ color: '#fff' }}>Send Message</Button.Label>}
+        </Button>
+      </View>
+    </Card>
+  );
+}

--- a/src/features/captain-engagement/hooks/use-captain-at-risk.ts
+++ b/src/features/captain-engagement/hooks/use-captain-at-risk.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../../core/config';
+import { fetchAtRiskPlayers } from '../services/captain-engagement.service';
+import { toCaptainAtRiskPlayer } from '../mappers/captain-engagement.mapper';
+import type { CaptainAtRiskPlayer } from '../types/captain-engagement.model';
+
+export function useCaptainAtRisk(leagueId: string) {
+  return useQuery<CaptainAtRiskPlayer[]>({
+    queryKey: queryKeys.leagues.captainAtRisk(leagueId),
+    queryFn: async () => {
+      const dtos = await fetchAtRiskPlayers(leagueId);
+      return dtos.map(toCaptainAtRiskPlayer);
+    },
+    enabled: !!leagueId,
+  });
+}

--- a/src/features/captain-engagement/hooks/use-milestone-drafts.ts
+++ b/src/features/captain-engagement/hooks/use-milestone-drafts.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '../../../core/config';
+import {
+  fetchMilestoneDrafts,
+  editMilestoneDraft,
+  sendMilestoneDraft,
+} from '../services/captain-engagement.service';
+import { toMilestoneDraft } from '../mappers/captain-engagement.mapper';
+import type { MilestoneDraft } from '../types/captain-engagement.model';
+
+export function useMilestoneDrafts(leagueId: string) {
+  return useQuery<MilestoneDraft[]>({
+    queryKey: queryKeys.leagues.milestoneDrafts(leagueId),
+    queryFn: async () => {
+      const dtos = await fetchMilestoneDrafts(leagueId);
+      return dtos.map(toMilestoneDraft);
+    },
+    enabled: !!leagueId,
+  });
+}
+
+export function useEditMilestoneDraft(leagueId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ draftId, content }: { draftId: string; content: string }) =>
+      editMilestoneDraft(draftId, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.milestoneDrafts(leagueId),
+      });
+    },
+  });
+}
+
+export function useSendMilestoneDraft(leagueId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (draftId: string) => sendMilestoneDraft(draftId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.milestoneDrafts(leagueId),
+      });
+    },
+  });
+}

--- a/src/features/captain-engagement/index.ts
+++ b/src/features/captain-engagement/index.ts
@@ -1,0 +1,4 @@
+export { useCaptainAtRisk } from './hooks/use-captain-at-risk';
+export { useMilestoneDrafts, useEditMilestoneDraft, useSendMilestoneDraft } from './hooks/use-milestone-drafts';
+export { CaptainAtRiskFeed } from './components/captain-at-risk-feed';
+export { MilestoneDraftCard } from './components/milestone-draft-card';

--- a/src/features/captain-engagement/mappers/captain-engagement.mapper.ts
+++ b/src/features/captain-engagement/mappers/captain-engagement.mapper.ts
@@ -1,0 +1,29 @@
+import type { AtRiskPlayerDTO, MilestoneDraftDTO } from '../types/captain-engagement.dto';
+import type { CaptainAtRiskPlayer, MilestoneDraft } from '../types/captain-engagement.model';
+
+export function toCaptainAtRiskPlayer(dto: AtRiskPlayerDTO): CaptainAtRiskPlayer {
+  return {
+    userId: dto.userId,
+    username: dto.username,
+    teamId: dto.teamId,
+    reason: dto.reason,
+    lastSubmissionAt: dto.lastSubmissionAt,
+    teamAverage: dto.teamAverage,
+    playerActivity: dto.playerActivity,
+  };
+}
+
+export function toMilestoneDraft(dto: MilestoneDraftDTO): MilestoneDraft {
+  return {
+    id: dto.id,
+    leagueId: dto.league_id,
+    type: dto.type,
+    targetScope: dto.target_scope,
+    targetId: dto.target_id,
+    content: dto.content,
+    status: dto.status,
+    milestoneType: dto.milestone_type,
+    createdAt: dto.created_at,
+    targetUsername: dto.target_user?.username ?? 'Player',
+  };
+}

--- a/src/features/captain-engagement/services/captain-engagement.service.ts
+++ b/src/features/captain-engagement/services/captain-engagement.service.ts
@@ -1,0 +1,40 @@
+import { api } from '../../../core/api';
+import type { AtRiskPlayerDTO, MilestoneDraftDTO } from '../types/captain-engagement.dto';
+
+export async function fetchAtRiskPlayers(
+  leagueId: string,
+): Promise<AtRiskPlayerDTO[]> {
+  const res = await api.get<AtRiskPlayerDTO[]>(
+    `/api/captain/at-risk?leagueId=${leagueId}`,
+  );
+  return res.data;
+}
+
+export async function fetchMilestoneDrafts(
+  leagueId: string,
+): Promise<MilestoneDraftDTO[]> {
+  const res = await api.get<MilestoneDraftDTO[]>(
+    `/api/captain/milestone-drafts?leagueId=${leagueId}`,
+  );
+  return res.data;
+}
+
+export async function editMilestoneDraft(
+  draftId: string,
+  content: string,
+): Promise<{ success: boolean }> {
+  const res = await api.patch<{ success: boolean }>(
+    `/api/captain/milestone-drafts/${draftId}`,
+    { content },
+  );
+  return res.data;
+}
+
+export async function sendMilestoneDraft(
+  draftId: string,
+): Promise<{ success: boolean }> {
+  const res = await api.post<{ success: boolean }>(
+    `/api/captain/milestone-drafts/${draftId}/send`,
+  );
+  return res.data;
+}

--- a/src/features/captain-engagement/types/captain-engagement.dto.ts
+++ b/src/features/captain-engagement/types/captain-engagement.dto.ts
@@ -1,0 +1,24 @@
+// DTO types — match backend /api/captain/* JSON shape
+
+export interface AtRiskPlayerDTO {
+  userId: string;
+  username: string;
+  teamId: string | null;
+  reason: 'inactive_48h' | 'below_team_average';
+  lastSubmissionAt: string | null;
+  teamAverage: number;
+  playerActivity: number;
+}
+
+export interface MilestoneDraftDTO {
+  id: string;
+  league_id: string;
+  type: string;
+  target_scope: string;
+  target_id?: string;
+  content: string;
+  status: string;
+  milestone_type?: string;
+  created_at: string;
+  target_user?: { username: string };
+}

--- a/src/features/captain-engagement/types/captain-engagement.model.ts
+++ b/src/features/captain-engagement/types/captain-engagement.model.ts
@@ -1,0 +1,24 @@
+// Domain models — camelCase
+
+export interface CaptainAtRiskPlayer {
+  userId: string;
+  username: string;
+  teamId: string | null;
+  reason: 'inactive_48h' | 'below_team_average';
+  lastSubmissionAt: string | null;
+  teamAverage: number;
+  playerActivity: number;
+}
+
+export interface MilestoneDraft {
+  id: string;
+  leagueId: string;
+  type: string;
+  targetScope: string;
+  targetId?: string;
+  content: string;
+  status: string;
+  milestoneType?: string;
+  createdAt: string;
+  targetUsername: string;
+}

--- a/src/features/captain-engagement/types/index.ts
+++ b/src/features/captain-engagement/types/index.ts
@@ -1,0 +1,2 @@
+export type * from './captain-engagement.dto';
+export type * from './captain-engagement.model';

--- a/src/features/engagement/components/at-risk-list.tsx
+++ b/src/features/engagement/components/at-risk-list.tsx
@@ -1,0 +1,67 @@
+import { View } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { AtRiskPlayer } from '../types/engagement.model';
+
+interface AtRiskListProps {
+  players: AtRiskPlayer[];
+}
+
+export function AtRiskList({ players }: AtRiskListProps) {
+  if (players.length === 0) {
+    return (
+      <Card className="p-4" style={{ borderLeftWidth: 3, borderLeftColor: mflColors.brand }}>
+        <AppText className="text-sm text-foreground font-medium text-center">
+          All players active — no one at risk
+        </AppText>
+      </Card>
+    );
+  }
+
+  return (
+    <View>
+      <View className="flex-row items-center mb-2">
+        <View style={{ width: 4, height: 14, backgroundColor: mflColors.danger, borderRadius: 2, marginRight: 8 }} />
+        <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+          At-Risk Players ({players.length})
+        </AppText>
+      </View>
+      {players.map((player) => (
+        <Card key={player.userId} className="p-3 mb-2">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-row items-center flex-1">
+              <View
+                className="w-8 h-8 rounded-full items-center justify-center mr-3"
+                style={{ backgroundColor: mflColors.inkLight }}
+              >
+                <AppText className="text-[10px] font-bold text-foreground">
+                  {player.username.slice(0, 2).toUpperCase()}
+                </AppText>
+              </View>
+              <View className="flex-1">
+                <AppText className="text-sm font-medium text-foreground">{player.username}</AppText>
+                <AppText className="text-[11px] text-muted">
+                  Last active: {player.lastActive ?? '30d+ ago'}
+                </AppText>
+              </View>
+            </View>
+            <View
+              className="rounded-full px-2 py-0.5"
+              style={{
+                backgroundColor: player.daysGap > 5 ? mflColors.dangerLight : mflColors.amberLight,
+              }}
+            >
+              <AppText
+                className="text-[10px] font-semibold"
+                style={{ color: player.daysGap > 5 ? mflColors.danger : mflColors.amber }}
+              >
+                {player.daysGap === 999 ? '30d+' : `${player.daysGap}d`}
+              </AppText>
+            </View>
+          </View>
+        </Card>
+      ))}
+    </View>
+  );
+}

--- a/src/features/engagement/components/daily-active-chart.tsx
+++ b/src/features/engagement/components/daily-active-chart.tsx
@@ -1,0 +1,50 @@
+import { View, Dimensions } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { DailyActiveUser } from '../types/engagement.model';
+
+interface DailyActiveChartProps {
+  data: DailyActiveUser[];
+}
+
+export function DailyActiveChart({ data }: DailyActiveChartProps) {
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+  const chartWidth = Dimensions.get('window').width - 64;
+  const barWidth = Math.max((chartWidth / data.length) - 4, 8);
+
+  return (
+    <Card className="p-4">
+      <View className="flex-row items-center mb-3">
+        <View style={{ width: 4, height: 14, backgroundColor: mflColors.brand, borderRadius: 2, marginRight: 8 }} />
+        <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+          Daily Active Users — Last 14 Days
+        </AppText>
+      </View>
+      <View className="flex-row items-end justify-between" style={{ height: 120 }}>
+        {data.map((day) => {
+          const barHeight = maxCount > 0 ? Math.max((day.count / maxCount) * 100, day.count > 0 ? 4 : 0) : 0;
+          return (
+            <View key={day.date} className="items-center" style={{ width: barWidth }}>
+              {day.count > 0 && (
+                <AppText className="text-[8px] text-muted mb-1">{day.count}</AppText>
+              )}
+              <View
+                style={{
+                  width: barWidth - 2,
+                  height: barHeight,
+                  backgroundColor: mflColors.brand,
+                  borderTopLeftRadius: 3,
+                  borderTopRightRadius: 3,
+                }}
+              />
+              <AppText className="text-[8px] text-muted mt-1">
+                {day.date.slice(5)}
+              </AppText>
+            </View>
+          );
+        })}
+      </View>
+    </Card>
+  );
+}

--- a/src/features/engagement/components/event-breakdown.tsx
+++ b/src/features/engagement/components/event-breakdown.tsx
@@ -1,0 +1,58 @@
+import { View } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { EventBreakdownItem } from '../types/engagement.model';
+
+const EVENT_COLORS: Record<string, string> = {
+  activity_log: '#22C55E',
+  chat_message: '#3B82F6',
+  login: '#F59E0B',
+  challenge_participation: '#A855F7',
+  ai_coach_interaction: '#14B8A6',
+  rest_day: '#94A3B8',
+  leaderboard_view: '#F97316',
+  profile_view: '#EC4899',
+};
+
+interface EventBreakdownProps {
+  items: EventBreakdownItem[];
+}
+
+export function EventBreakdown({ items }: EventBreakdownProps) {
+  const maxCount = Math.max(...items.map((i) => i.count), 1);
+
+  return (
+    <Card className="p-4 flex-1">
+      <View className="flex-row items-center mb-3">
+        <View style={{ width: 4, height: 14, backgroundColor: '#3B82F6', borderRadius: 2, marginRight: 8 }} />
+        <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+          Events — 30 Days
+        </AppText>
+      </View>
+      {items.length === 0 ? (
+        <AppText className="text-xs text-muted">No events recorded yet.</AppText>
+      ) : (
+        items.map((item) => (
+          <View key={item.type} className="mb-2">
+            <View className="flex-row items-center justify-between mb-1">
+              <AppText className="text-xs text-foreground capitalize">
+                {item.type.replace(/_/g, ' ')}
+              </AppText>
+              <AppText className="text-xs text-muted font-medium">{item.count}</AppText>
+            </View>
+            <View className="h-1 rounded-full overflow-hidden" style={{ backgroundColor: mflColors.inkLight }}>
+              <View
+                className="h-full rounded-full"
+                style={{
+                  width: `${(item.count / maxCount) * 100}%`,
+                  backgroundColor: EVENT_COLORS[item.type] ?? '#94A3B8',
+                }}
+              />
+            </View>
+          </View>
+        ))
+      )}
+    </Card>
+  );
+}

--- a/src/features/engagement/components/metric-card.tsx
+++ b/src/features/engagement/components/metric-card.tsx
@@ -1,0 +1,25 @@
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  color: string;
+  subtitle?: string;
+}
+
+export function MetricCard({ label, value, color, subtitle }: MetricCardProps) {
+  return (
+    <Card className="flex-1 p-4">
+      <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider mb-1">
+        {label}
+      </AppText>
+      <AppText className="text-2xl font-extrabold" style={{ color }}>
+        {value}
+      </AppText>
+      {subtitle && (
+        <AppText className="text-[11px] text-muted mt-0.5">{subtitle}</AppText>
+      )}
+    </Card>
+  );
+}

--- a/src/features/engagement/components/streak-distribution.tsx
+++ b/src/features/engagement/components/streak-distribution.tsx
@@ -1,0 +1,55 @@
+import { View } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { StreakBucket } from '../types/engagement.model';
+
+const STREAK_COLORS: Record<string, string> = {
+  '0': '#94A3B8',
+  '1-3': '#166534',
+  '4-7': '#16A34A',
+  '8-14': '#22C55E',
+  '15+': '#4ADE80',
+};
+
+interface StreakDistributionProps {
+  buckets: StreakBucket[];
+}
+
+export function StreakDistribution({ buckets }: StreakDistributionProps) {
+  const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+
+  return (
+    <Card className="p-4 flex-1">
+      <View className="flex-row items-center mb-3">
+        <View style={{ width: 4, height: 14, backgroundColor: mflColors.brand, borderRadius: 2, marginRight: 8 }} />
+        <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+          Streak Distribution
+        </AppText>
+      </View>
+      <View className="flex-row items-end justify-around" style={{ height: 80 }}>
+        {buckets.map((bucket) => {
+          const barHeight = maxCount > 0
+            ? Math.max((bucket.count / maxCount) * 60, bucket.count > 0 ? 4 : 0)
+            : 0;
+          return (
+            <View key={bucket.range} className="items-center flex-1">
+              <AppText className="text-[10px] text-muted">{bucket.count}</AppText>
+              <View
+                style={{
+                  width: '60%',
+                  height: barHeight,
+                  backgroundColor: STREAK_COLORS[bucket.range] ?? '#94A3B8',
+                  borderTopLeftRadius: 2,
+                  borderTopRightRadius: 2,
+                  marginVertical: 2,
+                }}
+              />
+              <AppText className="text-[10px] text-muted">{bucket.range}</AppText>
+            </View>
+          );
+        })}
+      </View>
+    </Card>
+  );
+}

--- a/src/features/engagement/components/top-engagers.tsx
+++ b/src/features/engagement/components/top-engagers.tsx
@@ -1,0 +1,55 @@
+import { View, ScrollView } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { TopEngager } from '../types/engagement.model';
+
+const RANK_COLORS = ['#F59E0B', '#94A3B8', '#92400E'];
+
+interface TopEngagersProps {
+  engagers: TopEngager[];
+}
+
+export function TopEngagers({ engagers }: TopEngagersProps) {
+  if (engagers.length === 0) return null;
+
+  return (
+    <View>
+      <View className="flex-row items-center mb-2">
+        <View style={{ width: 4, height: 14, backgroundColor: '#A855F7', borderRadius: 2, marginRight: 8 }} />
+        <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+          Top Engagers — 30 Days
+        </AppText>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        {engagers.map((engager, index) => (
+          <Card
+            key={engager.userId}
+            className="p-3 mr-3 items-center"
+            style={[
+              { minWidth: 100 },
+              index < 3 && { borderTopWidth: 2, borderTopColor: RANK_COLORS[index] },
+            ]}
+          >
+            <View
+              className="w-10 h-10 rounded-full items-center justify-center mb-2"
+              style={{ backgroundColor: mflColors.inkLight }}
+            >
+              <AppText className="text-xs font-bold text-foreground">
+                {engager.username.slice(0, 2).toUpperCase()}
+              </AppText>
+            </View>
+            <AppText className="text-xs font-medium text-foreground text-center" numberOfLines={1}>
+              {engager.username}
+            </AppText>
+            <View className="rounded-full px-2 py-0.5 mt-1" style={{ backgroundColor: mflColors.brandLight }}>
+              <AppText className="text-[10px] font-medium" style={{ color: mflColors.brand }}>
+                {engager.eventCount} events
+              </AppText>
+            </View>
+          </Card>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/src/features/engagement/hooks/use-engagement.ts
+++ b/src/features/engagement/hooks/use-engagement.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../../core/config';
+import { fetchEngagement } from '../services/engagement.service';
+import { toEngagementData } from '../mappers/engagement.mapper';
+import type { EngagementData } from '../types/engagement.model';
+
+export function useEngagement(leagueId: string) {
+  return useQuery<EngagementData>({
+    queryKey: queryKeys.leagues.engagement(leagueId),
+    queryFn: async () => {
+      const res = await fetchEngagement(leagueId);
+      return toEngagementData(res.data);
+    },
+    enabled: !!leagueId,
+  });
+}

--- a/src/features/engagement/index.ts
+++ b/src/features/engagement/index.ts
@@ -1,0 +1,7 @@
+export { useEngagement } from './hooks/use-engagement';
+export { MetricCard } from './components/metric-card';
+export { DailyActiveChart } from './components/daily-active-chart';
+export { EventBreakdown } from './components/event-breakdown';
+export { StreakDistribution } from './components/streak-distribution';
+export { AtRiskList } from './components/at-risk-list';
+export { TopEngagers } from './components/top-engagers';

--- a/src/features/engagement/mappers/engagement.mapper.ts
+++ b/src/features/engagement/mappers/engagement.mapper.ts
@@ -1,0 +1,40 @@
+import type { EngagementDataDTO } from '../types/engagement.dto';
+import type {
+  EngagementData,
+  EventBreakdownItem,
+  AtRiskPlayer,
+  TopEngager,
+} from '../types/engagement.model';
+
+export function toEngagementData(dto: EngagementDataDTO): EngagementData {
+  const eventBreakdown: EventBreakdownItem[] = Object.entries(
+    dto.eventBreakdown,
+  )
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const atRiskPlayers: AtRiskPlayer[] = dto.atRiskPlayers.map((p) => ({
+    userId: p.user_id,
+    username: p.username,
+    lastActive: p.last_active,
+    daysGap: p.days_gap,
+  }));
+
+  const topEngagers: TopEngager[] = dto.topEngagers.map((e) => ({
+    userId: e.user_id,
+    username: e.username,
+    eventCount: e.event_count,
+  }));
+
+  return {
+    participationRate: dto.participationRate,
+    totalMembers: dto.totalMembers,
+    activeUsersLast7Days: dto.activeUsersLast7Days,
+    dailyActiveUsers: dto.dailyActiveUsers,
+    eventBreakdown,
+    atRiskPlayers,
+    streakDistribution: dto.streakDistribution,
+    topEngagers,
+    exportedAt: dto.exportedAt,
+  };
+}

--- a/src/features/engagement/services/engagement.service.ts
+++ b/src/features/engagement/services/engagement.service.ts
@@ -1,0 +1,11 @@
+import { api } from '../../../core/api';
+import type { EngagementResponseDTO } from '../types/engagement.dto';
+
+export async function fetchEngagement(
+  leagueId: string,
+): Promise<EngagementResponseDTO> {
+  const res = await api.get<EngagementResponseDTO>(
+    `/api/leagues/${leagueId}/engagement`,
+  );
+  return res.data;
+}

--- a/src/features/engagement/types/engagement.dto.ts
+++ b/src/features/engagement/types/engagement.dto.ts
@@ -1,0 +1,41 @@
+// DTO types — match backend JSON shape
+
+export interface EngagementResponseDTO {
+  success: boolean;
+  data: EngagementDataDTO;
+}
+
+export interface EngagementDataDTO {
+  participationRate: number;
+  totalMembers: number;
+  activeUsersLast7Days: number;
+  dailyActiveUsers: DailyActiveUserDTO[];
+  eventBreakdown: Record<string, number>;
+  atRiskPlayers: AtRiskPlayerDTO[];
+  streakDistribution: StreakBucketDTO[];
+  topEngagers: TopEngagerDTO[];
+  exportedAt: string;
+}
+
+export interface DailyActiveUserDTO {
+  date: string;
+  count: number;
+}
+
+export interface AtRiskPlayerDTO {
+  user_id: string;
+  username: string;
+  last_active: string | null;
+  days_gap: number;
+}
+
+export interface StreakBucketDTO {
+  range: string;
+  count: number;
+}
+
+export interface TopEngagerDTO {
+  user_id: string;
+  username: string;
+  event_count: number;
+}

--- a/src/features/engagement/types/engagement.model.ts
+++ b/src/features/engagement/types/engagement.model.ts
@@ -1,0 +1,41 @@
+// Domain models — camelCase
+
+export interface EngagementData {
+  participationRate: number;
+  totalMembers: number;
+  activeUsersLast7Days: number;
+  dailyActiveUsers: DailyActiveUser[];
+  eventBreakdown: EventBreakdownItem[];
+  atRiskPlayers: AtRiskPlayer[];
+  streakDistribution: StreakBucket[];
+  topEngagers: TopEngager[];
+  exportedAt: string;
+}
+
+export interface DailyActiveUser {
+  date: string;
+  count: number;
+}
+
+export interface EventBreakdownItem {
+  type: string;
+  count: number;
+}
+
+export interface AtRiskPlayer {
+  userId: string;
+  username: string;
+  lastActive: string | null;
+  daysGap: number;
+}
+
+export interface StreakBucket {
+  range: string;
+  count: number;
+}
+
+export interface TopEngager {
+  userId: string;
+  username: string;
+  eventCount: number;
+}

--- a/src/features/engagement/types/index.ts
+++ b/src/features/engagement/types/index.ts
@@ -1,0 +1,2 @@
+export type * from './engagement.dto';
+export type * from './engagement.model';


### PR DESCRIPTION
## Summary
- Adds **Engagement Dashboard** screen (host/governor): participation rate, active users, daily active chart, event breakdown, streak distribution, at-risk players list, top engagers
- Adds **Captain Engagement** screen (captain/host/governor): at-risk feed with reason badges, milestone draft cards with edit + send
- Wires both screens into drawer navigation and Stack routes
- Adds query keys for engagement, captainAtRisk, milestoneDrafts
- Follows mobile architecture: DTOs, models, mappers, services, hooks, components

## Endpoints used
- `GET /api/leagues/{id}/engagement`
- `GET /api/captain/at-risk?leagueId={id}`
- `GET /api/captain/milestone-drafts?leagueId={id}`
- `PATCH /api/captain/milestone-drafts/{draftId}`
- `POST /api/captain/milestone-drafts/{draftId}/send`

## Skipped
- CSV export (web-only, no mobile equivalent pattern)
- Nudge button (disabled/coming-soon on web too)

## Test plan
- [ ] Host/governor sees Engagement Dashboard in drawer nav
- [ ] Engagement Dashboard loads metrics, charts, at-risk list, top engagers
- [ ] Pull-to-refresh works on Engagement Dashboard
- [ ] Captain sees Captain Engagement in drawer nav
- [ ] At-risk feed shows players with correct reason badges
- [ ] Milestone drafts load, edit saves, send delivers message
- [ ] Players without captain/host/governor role see RBAC guard