### PR TITLE
feat: My Team / My Activity UI parity with web

### DIFF
--- a/src/features/team/components/my-team-view-screen.tsx
+++ b/src/features/team/components/my-team-view-screen.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { View, Pressable } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { useRouter } from 'expo-router';
@@ -124,6 +124,15 @@ export function MyTeamViewScreen() {
   const stats = viewData?.stats;
   const captain = members.find((m) => m.isCaptain);
 
+  const membersWithPoints = useMemo(
+    () => members.filter((m) => m.points > 0).length,
+    [members],
+  );
+  const membersAtRisk = useMemo(
+    () => members.filter((m) => m.points === 0).length,
+    [members],
+  );
+
   return (
     <ScreenScrollView onRefresh={handleRefresh}>
       <View className="py-4 gap-4">
@@ -153,6 +162,83 @@ export function MyTeamViewScreen() {
           </AppText>
         </Pressable>
 
+        {/* Team Health Banner — active member count (matches web Zone 1) */}
+        {members.length > 0 && (
+          <View
+            className="rounded-2xl p-4"
+            style={{ borderWidth: 1, borderColor: mflColors.border, backgroundColor: mflColors.card }}
+          >
+            <View className="flex-row items-baseline gap-3 mb-2">
+              <AppText
+                className="text-[11px] uppercase"
+                style={{ color: mflColors.textMuted, letterSpacing: 1 }}
+              >
+                {teamName?.toUpperCase() ?? 'TEAM'}
+              </AppText>
+              <AppText
+                className="text-[40px] font-extrabold leading-none"
+                style={{ color: mflColors.amber }}
+              >
+                {stats?.teamRank ?? '#--'}
+              </AppText>
+            </View>
+            <View className="flex-row items-center">
+              <AppText
+                className="text-[13px] font-bold"
+                style={{ color: mflColors.brand }}
+              >
+                {membersWithPoints}
+              </AppText>
+              <AppText className="text-[13px] text-muted">
+                {' '}of {members.length} members with points
+              </AppText>
+            </View>
+          </View>
+        )}
+
+        {/* Captain Action Bar (matches web Zone 4) */}
+        {isCaptain && members.length > 0 && (
+          <View
+            className="rounded-2xl p-4"
+            style={{
+              borderLeftWidth: 4,
+              borderLeftColor: mflColors.amber,
+              borderWidth: 1,
+              borderColor: mflColors.border,
+              backgroundColor: mflColors.card,
+            }}
+          >
+            <AppText
+              className="text-[13px] font-bold mb-2"
+              style={{ color: mflColors.amber }}
+            >
+              Captain's Dashboard
+            </AppText>
+            <View className="flex-row items-center gap-3 flex-wrap">
+              <View className="flex-row items-center gap-1">
+                <AppText className="font-bold" style={{ color: mflColors.danger }}>
+                  {membersAtRisk}
+                </AppText>
+                <AppText className="text-xs text-muted">at risk</AppText>
+              </View>
+              <AppText className="text-xs text-muted">·</AppText>
+              <View className="flex-row items-center gap-1">
+                <AppText className="font-bold" style={{ color: mflColors.brand }}>
+                  {membersWithPoints}
+                </AppText>
+                <AppText className="text-xs text-muted">with points</AppText>
+              </View>
+              <AppText className="text-xs text-muted">·</AppText>
+              <View className="flex-row items-center gap-1">
+                <AppText className="font-bold" style={{ color: mflColors.blue }}>
+                  {members.length}
+                </AppText>
+                <AppText className="text-xs text-muted">total active</AppText>
+              </View>
+            </View>
+          </View>
+        )}
+
         {/* Stats Grid */}
         {stats && (
           <TeamViewStats
@@ -168,6 +254,7 @@ export function MyTeamViewScreen() {
           members={members}
           showRR={showRR}
           showRestDays={showRestDays}
+          isCaptain={isCaptain}
         />
       </View>
     </ScreenScrollView>

--- a/src/features/team/components/team-view-roster.tsx
+++ b/src/features/team/components/team-view-roster.tsx
@@ -1,5 +1,6 @@
+import { useMemo } from 'react';
 import { View } from 'react-native';
-import { Avatar, Card, Chip, Separator } from 'heroui-native';
+import { Avatar, Card, Chip } from 'heroui-native';
 import Feather from '@expo/vector-icons/Feather';
 import { AppText } from '../../../components/app-text';
 import { SectionLabel } from '../../../components/section-label';
@@ -20,35 +21,64 @@ function capitalizeName(name: string): string {
     .join(' ');
 }
 
+/** Top-3 left-border colors matching web's gold/silver/bronze */
+const RANK_BORDER_COLORS = ['#F59E0B', '#94A3B8', '#B45309'] as const;
+
 interface TeamViewRosterProps {
   members: TeamMember[];
   showRR: boolean;
   showRestDays: boolean;
+  isCaptain?: boolean;
 }
 
 export function TeamViewRoster({
   members,
   showRR,
   showRestDays,
+  isCaptain = false,
 }: TeamViewRosterProps) {
+  const highestPoints = useMemo(
+    () => Math.max(...members.map((m) => m.points || 0), 1),
+    [members],
+  );
+
   return (
     <View className="gap-2">
       <SectionLabel label={`Team Members (${members.length})`} />
 
-      <Card className="p-4">
-        {members.length > 0 ? (
-          members.map((member, index) => (
-            <View key={member.leagueMemberId}>
-              {index > 0 && <Separator className="my-0" />}
-              <View className="flex-row items-center py-3 gap-3">
-                {/* Rank */}
-                <AppText className="text-xs text-muted w-5 text-center">
-                  {index + 1}
-                </AppText>
+      {members.length > 0 ? (
+        members.map((member, index) => {
+          const isAtRisk = member.points === 0;
+          const progressPct =
+            highestPoints > 0 ? (member.points / highestPoints) * 100 : 0;
+          const rankBorderColor =
+            index < 3 ? RANK_BORDER_COLORS[index] : undefined;
 
+          return (
+            <Card
+              key={member.leagueMemberId}
+              className="p-4"
+              style={
+                rankBorderColor
+                  ? { borderLeftWidth: 3, borderLeftColor: rankBorderColor }
+                  : undefined
+              }
+            >
+              {/* Top: avatar + name + stats */}
+              <View className="flex-row items-start gap-3">
                 {/* Avatar with captain badge */}
                 <View>
-                  <Avatar size="md" alt={member.username}>
+                  <Avatar
+                    size="md"
+                    alt={member.username}
+                    style={
+                      member.isCaptain
+                        ? { borderWidth: 2, borderColor: mflColors.amber }
+                        : isAtRisk
+                          ? { borderWidth: 2, borderColor: mflColors.danger }
+                          : undefined
+                    }
+                  >
                     {member.profilePictureUrl ? (
                       <Avatar.Image
                         source={{ uri: member.profilePictureUrl }}
@@ -73,20 +103,42 @@ export function TeamViewRoster({
                   )}
                 </View>
 
-                {/* Name + role chip */}
-                <View className="flex-1 gap-0.5">
-                  <AppText
-                    className="text-sm font-semibold text-foreground"
-                    numberOfLines={1}
-                  >
-                    {capitalizeName(member.username)}
-                  </AppText>
-                  {member.isCaptain ? (
-                    <Chip size="sm" variant="soft">
-                      <Chip.Label>Captain</Chip.Label>
-                    </Chip>
-                  ) : (
-                    <AppText className="text-[10px] text-muted">Player</AppText>
+                {/* Name + role + at-risk chip */}
+                <View className="flex-1 gap-1">
+                  <View className="flex-row items-center gap-2 flex-wrap">
+                    <AppText
+                      className="text-sm font-semibold text-foreground"
+                      numberOfLines={1}
+                    >
+                      {capitalizeName(member.username)}
+                    </AppText>
+                    {member.isCaptain ? (
+                      <Chip size="sm" variant="soft">
+                        <Chip.Label>Captain</Chip.Label>
+                      </Chip>
+                    ) : (
+                      <AppText className="text-[10px] text-muted">
+                        Player
+                      </AppText>
+                    )}
+                  </View>
+                  {isAtRisk && isCaptain && (
+                    <View
+                      className="flex-row items-center gap-1 self-start rounded-full px-2 py-0.5"
+                      style={{ backgroundColor: mflColors.dangerLight }}
+                    >
+                      <Feather
+                        name="alert-triangle"
+                        size={10}
+                        color={mflColors.danger}
+                      />
+                      <AppText
+                        className="text-[10px] font-semibold"
+                        style={{ color: mflColors.danger }}
+                      >
+                        At risk
+                      </AppText>
+                    </View>
                   )}
                 </View>
 
@@ -113,16 +165,49 @@ export function TeamViewRoster({
                   )}
                 </View>
               </View>
-            </View>
-          ))
-        ) : (
+
+              {/* Contribution bar */}
+              <View className="mt-3">
+                <AppText
+                  className="text-[9px] uppercase mb-1"
+                  style={{
+                    color: mflColors.textMuted,
+                    letterSpacing: 0.8,
+                  }}
+                >
+                  CONTRIBUTION
+                </AppText>
+                {progressPct > 0 ? (
+                  <View
+                    className="h-1.5 rounded-full overflow-hidden"
+                    style={{ backgroundColor: mflColors.inkLight }}
+                  >
+                    <View
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${progressPct}%`,
+                        backgroundColor: mflColors.brand,
+                      }}
+                    />
+                  </View>
+                ) : (
+                  <AppText className="text-[10px] text-muted">
+                    No activity yet
+                  </AppText>
+                )}
+              </View>
+            </Card>
+          );
+        })
+      ) : (
+        <Card className="p-4">
           <View className="py-6 items-center">
             <AppText className="text-sm text-muted">
               No members in this team yet.
             </AppText>
           </View>
-        )}
-      </Card>
+        </Card>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Add Team Health Banner with large rank display and active member count (web Zone 1)
- Add Captain Action Bar with at-risk/with-points/total-active breakdown (web Zone 4)
- Upgrade roster to individual member cards with contribution progress bars, top-3 gold/silver/bronze borders, at-risk indicators, and avatar ring styling

## Test plan
- [ ] Verify Team Health Banner renders rank and active member count on My Team View
- [ ] Verify Captain Action Bar appears only for captains with correct counts
- [ ] Verify contribution bars scale relative to top scorer
- [ ] Verify "At risk" chip appears on 0-point members for captains only
- [ ] Verify top-3 left-border colors (gold/silver/bronze)
- [ ] Test on both iOS and Android (no nested AppText issues)