### PR TITLE
fix: team chat web-to-mobile parity — 10 gaps closed

### DIFF
--- a/src/features/messaging/components/chat-composer.tsx
+++ b/src/features/messaging/components/chat-composer.tsx
@@ -1,7 +1,7 @@
 import Feather from '@expo/vector-icons/Feather';
 import * as ImagePicker from 'expo-image-picker';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Image,
@@ -48,6 +48,10 @@ interface ChatComposerProps {
   replyTo: ChatMessage | null;
   onCancelReply: () => void;
   onSent: () => void;
+  senderId?: string;
+  senderUsername?: string;
+  onOptimisticMessage?: (message: ChatMessage) => void;
+  onSendFailed?: (messageId: string) => void;
 }
 
 export function ChatComposer({
@@ -59,6 +63,10 @@ export function ChatComposer({
   replyTo,
   onCancelReply,
   onSent,
+  senderId,
+  senderUsername,
+  onOptimisticMessage,
+  onSendFailed,
 }: ChatComposerProps) {
   const sendMutation = useSendChatMessage();
   const [content, setContent] = useState('');
@@ -149,6 +157,8 @@ export function ChatComposer({
     }
   };
 
+  const optimisticIdRef = useRef<string | null>(null);
+
   const handleSend = async () => {
     if (!canSend || isBusy) return;
 
@@ -172,6 +182,36 @@ export function ChatComposer({
       setUploadingPhoto(false);
     }
 
+    // Build and inject optimistic message immediately
+    if (onOptimisticMessage && senderId) {
+      const optimisticId = `optimistic-${Date.now()}`;
+      optimisticIdRef.current = optimisticId;
+      const optimistic: ChatMessage = {
+        messageId: optimisticId,
+        leagueId,
+        teamId: teamId ?? null,
+        senderId,
+        senderName: senderUsername ?? null,
+        senderUsername: senderUsername ?? 'You',
+        senderRole: currentRole,
+        content: content.trim() || (photoUrl ? 'Photo' : ''),
+        messageType: isAnnouncement ? 'announcement' : 'chat',
+        visibility,
+        isImportant,
+        parentMessageId: replyTo?.messageId ?? null,
+        parentMessage: replyTo
+          ? { senderUsername: replyTo.senderUsername, content: replyTo.content }
+          : null,
+        deepLink: deepLink ?? null,
+        photoUrl: photoUrl ?? (photo ? photo.uri : null),
+        createdAt: new Date().toISOString(),
+        editedAt: null,
+        isRead: true,
+        reactions: [],
+      };
+      onOptimisticMessage(optimistic);
+    }
+
     sendMutation.mutate(
       {
         leagueId,
@@ -186,6 +226,7 @@ export function ChatComposer({
       },
       {
         onSuccess: () => {
+          optimisticIdRef.current = null;
           setContent('');
           setVisibility('all');
           setIsAnnouncement(false);
@@ -196,6 +237,10 @@ export function ChatComposer({
           onSent();
         },
         onError: (error) => {
+          if (optimisticIdRef.current && onSendFailed) {
+            onSendFailed(optimisticIdRef.current);
+          }
+          optimisticIdRef.current = null;
           Alert.alert('Send Failed', error.message);
         },
       },
@@ -266,7 +311,7 @@ export function ChatComposer({
             ) : null}
             {visibility === 'captains_only' ? (
               <MessagingChip
-                label={currentRole === 'player' ? 'DM Captain' : 'Captains Only'}
+                label={currentRole === 'player' ? 'DM to Captain' : 'Captains Only'}
                 icon="shield"
                 selected
                 onPress={() => setVisibility('all')}

--- a/src/features/messaging/components/chat-message-bubble.tsx
+++ b/src/features/messaging/components/chat-message-bubble.tsx
@@ -1,5 +1,6 @@
 import Feather from '@expo/vector-icons/Feather';
-import { Image, Pressable, View } from 'react-native';
+import { useState } from 'react';
+import { Dimensions, Image, Modal, Pressable, View } from 'react-native';
 
 import { AppText } from '../../../components/app-text';
 import { mflColors } from '../../../constants/colors';
@@ -13,12 +14,13 @@ import {
 import { renderMessageContent } from '../utils/render-message-content';
 import { MessagingChip } from './messaging-chip';
 
-const QUICK_EMOJIS = ['👍', '❤️', '😂', '🎉', '💪', '🔥'];
+const QUICK_EMOJIS = ['\u{1F44D}', '\u{1F525}', '\u{1F4AA}', '\u{1F602}', '\u{2764}\u{FE0F}', '\u{1F440}'];
 
 interface ChatMessageBubbleProps {
   message: ChatMessage;
   isOwn: boolean;
   currentUserId?: string;
+  isGrouped?: boolean;
   onReply: (message: ChatMessage) => void;
   onReact: (messageId: string, emoji: string) => void;
   onOpenDeepLink: (path: string) => void;
@@ -28,12 +30,20 @@ export function ChatMessageBubble({
   message,
   isOwn,
   currentUserId,
+  isGrouped = false,
   onReply,
   onReact,
   onOpenDeepLink,
 }: ChatMessageBubbleProps) {
-  const isAnnouncement = message.messageType === 'announcement';
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
   const isSystem = message.messageType === 'system';
+  const isCaptainBoost =
+    message.messageType === 'announcement' &&
+    message.visibility === 'captains_only';
+  const isAnnouncement =
+    message.messageType === 'announcement' &&
+    message.visibility !== 'captains_only';
   const roleColor = getRoleColor(message.senderRole);
 
   if (isSystem) {
@@ -46,24 +56,88 @@ export function ChatMessageBubble({
     );
   }
 
+  // Captain boost: announcement + captains_only = golden card (matches web)
+  if (isCaptainBoost) {
+    return (
+      <View className={isGrouped ? 'mt-1' : 'mt-3'}>
+        <Pressable
+          onLongPress={() => onReply(message)}
+          className="rounded-xl px-4 py-3"
+          style={{
+            backgroundColor: mflColors.amberLight,
+            borderWidth: 1,
+            borderColor: '#FCD34D',
+          }}
+        >
+          <AppText className="text-[15px] text-foreground">
+            {renderMessageContent(message.content, mflColors.text)}
+          </AppText>
+          <View className="mt-2 flex-row items-center gap-2">
+            <AppText className="text-[10px] font-semibold" style={{ color: mflColors.amber }}>
+              {message.senderName || message.senderUsername}
+            </AppText>
+            <AppText className="text-[10px] text-muted">
+              {formatRelativeMessageTime(message.createdAt)}
+            </AppText>
+          </View>
+        </Pressable>
+
+        {message.reactions.length > 0 ? (
+          <View className="mt-1 flex-row flex-wrap gap-1">
+            {message.reactions.map((reaction) => (
+              <MessagingChip
+                key={reaction.emoji}
+                label={`${reaction.emoji} ${reaction.userIds.length}`}
+                selected={!!currentUserId && reaction.userIds.includes(currentUserId)}
+                onPress={() => onReact(message.messageId, reaction.emoji)}
+              />
+            ))}
+          </View>
+        ) : null}
+
+        <View className="mt-1 flex-row flex-wrap gap-1">
+          <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
+          {QUICK_EMOJIS.map((emoji) => (
+            <MessagingChip
+              key={emoji}
+              label={emoji}
+              selected={message.reactions.some(
+                (reaction) =>
+                  reaction.emoji === emoji &&
+                  !!currentUserId &&
+                  reaction.userIds.includes(currentUserId),
+              )}
+              onPress={() => onReact(message.messageId, emoji)}
+            />
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  const screenWidth = Dimensions.get('window').width;
+
   return (
     <View className={isOwn ? 'items-end' : 'items-start'}>
       <View
-        className="mb-2 flex-row"
+        className={`flex-row ${isGrouped ? 'mt-1' : 'mt-3'}`}
         style={{
           maxWidth: '86%',
           alignSelf: isOwn ? 'flex-end' : 'flex-start',
         }}
       >
-        {!isOwn ? (
+        {/* Avatar — hide for own messages; show spacer when grouped */}
+        {!isOwn && !isGrouped ? (
           <View
-            className="mr-2 mt-1 h-8 w-8 items-center justify-center rounded-full"
+            className="mr-2 mt-1 h-7 w-7 items-center justify-center rounded-full"
             style={{ backgroundColor: mflColors.brandLight }}
           >
-            <AppText className="text-xs font-bold" style={{ color: mflColors.brand }}>
+            <AppText className="text-[10px] font-bold" style={{ color: mflColors.brand }}>
               {getInitial(message.senderUsername)}
             </AppText>
           </View>
+        ) : !isOwn && isGrouped ? (
+          <View className="mr-2 h-7 w-7" />
         ) : null}
 
         <Pressable
@@ -89,14 +163,20 @@ export function ChatMessageBubble({
                   },
           ]}
         >
-          {!isOwn ? (
+          {/* Name + role badge — hide when grouped or own */}
+          {!isOwn && !isGrouped ? (
             <View className="mb-1 flex-row items-center gap-2">
               <AppText className="text-xs font-semibold" style={{ color: roleColor }}>
                 {message.senderName || message.senderUsername}
               </AppText>
               <View
                 className="rounded-full px-1.5 py-0.5"
-                style={{ backgroundColor: mflColors.surface }}
+                style={{
+                  backgroundColor: mflColors.surface,
+                  ...(message.senderRole === 'player'
+                    ? { borderWidth: 1, borderColor: mflColors.border }
+                    : {}),
+                }}
               >
                 <AppText className="text-[10px] font-semibold" style={{ color: roleColor }}>
                   {getRoleLabel(message.senderRole)}
@@ -148,12 +228,14 @@ export function ChatMessageBubble({
           ) : null}
 
           {message.photoUrl ? (
-            <Image
-              source={{ uri: message.photoUrl }}
-              className="mb-2 rounded-xl"
-              style={{ width: 220, height: 170, backgroundColor: mflColors.surface }}
-              resizeMode="cover"
-            />
+            <Pressable onPress={() => setLightboxOpen(true)}>
+              <Image
+                source={{ uri: message.photoUrl }}
+                className="mb-2 rounded-xl"
+                style={{ width: 220, height: 170, backgroundColor: mflColors.surface }}
+                resizeMode="cover"
+              />
+            </Pressable>
           ) : null}
 
           {message.content ? (
@@ -225,11 +307,14 @@ export function ChatMessageBubble({
               {formatRelativeMessageTime(message.createdAt)}
             </AppText>
             {isOwn ? (
-              <Feather
-                name={message.isRead ? 'check-circle' : 'check'}
-                size={12}
-                color={message.isRead ? mflColors.blue : 'rgba(255,255,255,0.72)'}
-              />
+              message.isRead ? (
+                <View className="flex-row" style={{ marginLeft: -2 }}>
+                  <Feather name="check" size={12} color={mflColors.blue} />
+                  <Feather name="check" size={12} color={mflColors.blue} style={{ marginLeft: -6 }} />
+                </View>
+              ) : (
+                <Feather name="check" size={12} color="rgba(255,255,255,0.72)" />
+              )
             ) : null}
           </View>
         </Pressable>
@@ -263,6 +348,38 @@ export function ChatMessageBubble({
             />
           ))}
         </View>
+      ) : null}
+
+      {/* Photo lightbox */}
+      {message.photoUrl ? (
+        <Modal
+          visible={lightboxOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setLightboxOpen(false)}
+        >
+          <Pressable
+            onPress={() => setLightboxOpen(false)}
+            className="flex-1 items-center justify-center"
+            style={{ backgroundColor: 'rgba(0,0,0,0.9)' }}
+          >
+            <Pressable
+              onPress={() => setLightboxOpen(false)}
+              className="absolute right-4 top-14 z-10 rounded-full p-2"
+              style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}
+            >
+              <Feather name="x" size={22} color={mflColors.white} />
+            </Pressable>
+            <Image
+              source={{ uri: message.photoUrl }}
+              style={{
+                width: screenWidth - 32,
+                height: (screenWidth - 32) * 0.75,
+              }}
+              resizeMode="contain"
+            />
+          </Pressable>
+        </Modal>
       ) : null}
     </View>
   );

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -1,10 +1,11 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useRouter } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   FlatList,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   RefreshControl,
   View,
   type ListRenderItemInfo,
@@ -17,6 +18,7 @@ import { ScreenState } from '../../../components/screen-state';
 import { mflColors } from '../../../constants/colors';
 import { useAuth } from '../../../core/auth';
 import { useRole } from '../../../contexts/role-context';
+import { useUserProfile } from '../../profile/hooks/use-user-profile';
 import type { UserLeague } from '../../leagues/types/league.model';
 import { useChatMessages } from '../hooks/use-chat-messages';
 import { useChatTeams } from '../hooks/use-chat-teams';
@@ -56,6 +58,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
   const leagueId = league.leagueId;
   const isLeader = isHost || isGovernor;
   const isCaptainRole = isCaptain || isViceCaptain;
+  const profileQuery = useUserProfile();
 
   const teamsQuery = useChatTeams(leagueId, isLeader);
   const teams = teamsQuery.data ?? [];
@@ -92,6 +95,12 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
   const reactionMutation = useToggleChatReaction();
 
   const messages = messagesQuery.data ?? [];
+  const flatListRef = useRef<FlatList<ChatMessage>>(null);
+
+  const pinnedMessage = useMemo(
+    () => messages.find((m) => m.messageType === 'announcement' && m.isImportant),
+    [messages],
+  );
 
   useEffect(() => {
     const unreadIds = messages
@@ -147,23 +156,65 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
     [router],
   );
 
+  const activeQueryKey = useMemo(
+    () =>
+      messagingQueryKeys.messages(leagueId, {
+        teamId: channelTeamId ?? null,
+        filter,
+        adminView: isLeader && !!selectedTeamId && adminView,
+      }),
+    [leagueId, channelTeamId, filter, isLeader, selectedTeamId, adminView],
+  );
+
+  const handleOptimisticMessage = useCallback(
+    (optimistic: ChatMessage) => {
+      queryClient.setQueryData<ChatMessage[]>(activeQueryKey, (old) => [
+        optimistic,
+        ...(old ?? []),
+      ]);
+    },
+    [activeQueryKey, queryClient],
+  );
+
+  const handleSendFailed = useCallback(
+    (msgId: string) => {
+      queryClient.setQueryData<ChatMessage[]>(activeQueryKey, (old) =>
+        (old ?? []).filter((m) => m.messageId !== msgId),
+      );
+    },
+    [activeQueryKey, queryClient],
+  );
+
   const renderMessage = useCallback(
-    ({ item }: ListRenderItemInfo<ChatMessage>) => (
-      <ChatMessageBubble
-        message={item}
-        isOwn={item.senderId === user?.id}
-        currentUserId={user?.id}
-        onReply={setReplyTo}
-        onReact={(messageId, emoji) => {
-          reactionMutation.mutate(
-            { leagueId, messageId, emoji },
-            { onSuccess: () => messagesQuery.refetch() },
-          );
-        }}
-        onOpenDeepLink={openDeepLink}
-      />
-    ),
-    [leagueId, messagesQuery, openDeepLink, reactionMutation, user?.id],
+    ({ item, index }: ListRenderItemInfo<ChatMessage>) => {
+      // In inverted FlatList, data[0] = newest (bottom). The message visually
+      // above item[index] is item[index+1]. Group if same sender within 5 min.
+      const above = messages[index + 1];
+      const isGrouped =
+        !!above &&
+        above.senderId === item.senderId &&
+        Math.abs(
+          new Date(item.createdAt).getTime() - new Date(above.createdAt).getTime(),
+        ) < 5 * 60 * 1000;
+
+      return (
+        <ChatMessageBubble
+          message={item}
+          isOwn={item.senderId === user?.id}
+          currentUserId={user?.id}
+          isGrouped={isGrouped}
+          onReply={setReplyTo}
+          onReact={(messageId, emoji) => {
+            reactionMutation.mutate(
+              { leagueId, messageId, emoji },
+              { onSuccess: () => messagesQuery.refetch() },
+            );
+          }}
+          onOpenDeepLink={openDeepLink}
+        />
+      );
+    },
+    [leagueId, messages, messagesQuery, openDeepLink, reactionMutation, user?.id],
   );
 
   const keyExtractor = useCallback((item: ChatMessage) => item.messageId, []);
@@ -230,6 +281,33 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
         </View>
       </View>
 
+      {pinnedMessage ? (
+        <Pressable
+          onPress={() => {
+            const idx = messages.findIndex((m) => m.messageId === pinnedMessage.messageId);
+            if (idx >= 0) {
+              flatListRef.current?.scrollToIndex({ index: idx, animated: true, viewPosition: 0.5 });
+            }
+          }}
+          className="mx-4 mb-2 flex-row items-center gap-3 rounded-xl border px-4 py-3"
+          style={{
+            backgroundColor: mflColors.amberLight,
+            borderColor: 'rgba(245,158,11,0.2)',
+          }}
+        >
+          <AppText className="text-sm">📌</AppText>
+          <AppText
+            className="flex-1 text-[13px] text-foreground"
+            numberOfLines={1}
+          >
+            {pinnedMessage.content}
+          </AppText>
+          <AppText className="text-[11px] font-medium" style={{ color: mflColors.amber }}>
+            View
+          </AppText>
+        </Pressable>
+      ) : null}
+
       <View className="flex-1">
         {messagesQuery.isLoading ? (
           <ScreenState screen="team-chat" state="loading" />
@@ -243,6 +321,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
           />
         ) : (
           <FlatList
+            ref={flatListRef}
             data={messages}
             renderItem={renderMessage}
             keyExtractor={keyExtractor}
@@ -296,6 +375,10 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
               messagesQuery.refetch();
               unreadQuery.refetch();
             }}
+            senderId={user?.id}
+            senderUsername={profileQuery.data?.username}
+            onOptimisticMessage={handleOptimisticMessage}
+            onSendFailed={handleSendFailed}
           />
         </View>
       )}

--- a/src/features/messaging/hooks/use-unread-chat-count.ts
+++ b/src/features/messaging/hooks/use-unread-chat-count.ts
@@ -10,7 +10,7 @@ export function useUnreadChatCount(leagueId: string) {
       return dto.data.unread ?? dto.data.count;
     },
     enabled: !!leagueId,
-    staleTime: 30 * 1000,
-    refetchInterval: 30 * 1000,
+    staleTime: 10 * 1000,
+    refetchInterval: 10 * 1000,
   });
 }


### PR DESCRIPTION
## Summary
- Align emoji set to web (👍🔥💪😂❤️👀)
- Add message grouping (same sender within 5min hides avatar/name)
- Add pinned message banner for important announcements with tap-to-scroll
- Add photo lightbox modal on tap
- Fix read receipts to double-check (✓✓) pattern matching web
- Add player role badge (outlined style)
- Add captain boost card rendering (announcement + captains_only → golden card)
- Add optimistic message rendering with rollback on failure
- Fix "DM Captain" → "DM to Captain" label to match web
- Unread badge polling 30s → 10s to match web

## Files changed
- `src/features/messaging/components/chat-message-bubble.tsx`
- `src/features/messaging/components/team-messaging-screen.tsx`
- `src/features/messaging/components/chat-composer.tsx`
- `src/features/messaging/hooks/use-unread-chat-count.ts`

## Validation
- `npx tsc --noEmit`: 0 new errors
- `npx expo install --check`: 0 new dependency issues

## Test plan
- [ ] Verify emoji picker shows 👍🔥💪😂❤️👀 in correct order
- [ ] Send multiple messages as same user — confirm grouping (compact avatar)
- [ ] Send an important announcement — confirm pinned banner appears, tap scrolls to it
- [ ] Tap a photo in chat — confirm lightbox opens full-screen with close button
- [ ] Send a message — confirm double-check (✓✓) for read, single ✓ for sent
- [ ] View message from a player — confirm "player" badge with outline style
- [ ] Send announcement with captains_only visibility — confirm golden boost card
- [ ] Send a message — confirm it appears instantly before server confirms
- [ ] Fail a send (airplane mode) — confirm optimistic message is removed
- [ ] Check visibility chip shows "DM to Captain" for player role
- [ ] Verify unread badge updates within ~10s