### PR TITLE
feat: leaderboard rank banner, tiebreaker info & team balance score

### DIFF
--- a/src/core/config/query-keys.ts
+++ b/src/core/config/query-keys.ts
@@ -39,6 +39,7 @@ export const queryKeys = {
     teamSubmissions: (id: string) => [...queryKeys.leagues.all, id, 'team-submissions'] as const,
     partnerActivity: (id: string, teamId?: string) => [...queryKeys.leagues.all, id, 'partner-activity', teamId] as const,
     teamView: (id: string, teamId: string) => [...queryKeys.leagues.all, id, 'team-view', teamId] as const,
+    teamBalance: (id: string) => [...queryKeys.leagues.all, id, 'team-balance'] as const,
     teamSummary: (id: string) => [...queryKeys.leagues.all, id, 'my-team-summary'] as const,
     sponsors: (id: string) => [...queryKeys.leagues.all, id, 'sponsors'] as const,
     wearableConnections: (id: string) => [...queryKeys.leagues.all, id, 'wearable-connections'] as const,

--- a/src/features/leaderboard/components/leaderboard-screen.tsx
+++ b/src/features/leaderboard/components/leaderboard-screen.tsx
@@ -16,6 +16,7 @@ import {
 } from './leaderboard-filter-bar';
 import { OverallLeaderboard } from './overall-leaderboard';
 import { ChallengeLeaderboardSection } from './challenge-leaderboard-section';
+import { RankBanner } from './rank-banner';
 import {
   calculateWeekPresets,
   formatDateRange,
@@ -61,6 +62,18 @@ export function LeaderboardScreen() {
     if (!league?.start_date || !league?.end_date) return [];
     return calculateWeekPresets(league.start_date, league.end_date);
   }, [league?.start_date, league?.end_date]);
+
+  const userTeamId = activeLeague?.teamId ?? null;
+  const userTeamRanking = useMemo(() => {
+    if (!userTeamId || !data?.teams) return null;
+    return data.teams.find((t) => t.team_id === userTeamId) ?? null;
+  }, [data?.teams, userTeamId]);
+
+  const nextRankPoints = useMemo(() => {
+    if (!userTeamRanking || userTeamRanking.rank === 1 || !data?.teams) return undefined;
+    const nextTeam = data.teams.find((t) => t.rank === userTeamRanking.rank - 1);
+    return nextTeam?.total_points;
+  }, [data?.teams, userTeamRanking]);
 
   const roleLabel = isHost
     ? 'Host'
@@ -210,6 +223,21 @@ export function LeaderboardScreen() {
             </View>
           ) : null}
         </Animated.View>
+
+        {userTeamRanking && activeTab === 'teams' ? (
+          <Animated.View entering={FadeInDown.duration(250).delay(50)}>
+            <RankBanner
+              rank={userTeamRanking.rank}
+              totalTeams={data.teams.length}
+              points={userTeamRanking.total_points}
+              teamName={userTeamRanking.team_name}
+              nextRankPoints={nextRankPoints}
+              primaryColor={
+                activeLeague?.branding?.primary_color as string | undefined
+              }
+            />
+          </Animated.View>
+        ) : null}
 
         <Animated.View entering={FadeInDown.duration(250).delay(60)}>
           <LeaderboardFilterBar

--- a/src/features/leaderboard/components/overall-leaderboard.tsx
+++ b/src/features/leaderboard/components/overall-leaderboard.tsx
@@ -5,6 +5,7 @@ import { SectionLabel } from '../../../components/section-label';
 import type { LeaderboardDataDTO } from '../types/leaderboard.dto';
 import { TeamRankingCard, IndividualRankingCard } from './ranking-cards';
 import { LeaderboardStatsBar } from './leaderboard-stats-bar';
+import { TiebreakerInfo } from './tiebreaker-info';
 
 export function OverallLeaderboard({
   data,
@@ -50,6 +51,7 @@ export function OverallLeaderboard({
             ))}
           </View>
         )}
+        {showAvgRR ? <TiebreakerInfo /> : null}
       </View>
 
       <View className="gap-3">

--- a/src/features/leaderboard/components/rank-banner.tsx
+++ b/src/features/leaderboard/components/rank-banner.tsx
@@ -1,0 +1,139 @@
+import Feather from '@expo/vector-icons/Feather';
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+
+interface RankBannerProps {
+  rank: number;
+  totalTeams: number;
+  points: number;
+  teamName: string;
+  nextRankPoints?: number;
+  primaryColor?: string;
+}
+
+function getOrdinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] ?? s[v] ?? s[0] ?? 'th');
+}
+
+function isValidHex(color?: string): boolean {
+  if (!color) return false;
+  return /^#([0-9A-F]{3}){1,2}$/i.test(color);
+}
+
+export function RankBanner({
+  rank,
+  totalTeams,
+  points,
+  teamName,
+  nextRankPoints,
+  primaryColor,
+}: RankBannerProps) {
+  const pointsToNext = nextRankPoints ? nextRankPoints - points : 0;
+  const safePrimaryColor = isValidHex(primaryColor) ? primaryColor : mflColors.brand;
+
+  const trophyColor =
+    rank === 1
+      ? '#FBBF24'
+      : rank === 2
+        ? '#CBD5E1'
+        : rank === 3
+          ? '#FB923C'
+          : '#FFFFFF99';
+
+  return (
+    <View
+      className="overflow-hidden rounded-2xl p-5"
+      style={{
+        backgroundColor: safePrimaryColor,
+      }}
+    >
+      <View className="flex-row items-center gap-4">
+        <View
+          className="h-14 w-14 items-center justify-center rounded-2xl"
+          style={{ backgroundColor: 'rgba(255,255,255,0.12)' }}
+        >
+          <Feather name="award" size={28} color={trophyColor} />
+        </View>
+
+        <View className="flex-1">
+          <AppText
+            className="text-[10px] font-bold uppercase tracking-widest"
+            style={{ color: 'rgba(255,255,255,0.7)' }}
+            numberOfLines={1}
+          >
+            {teamName}
+          </AppText>
+          <View className="flex-row items-baseline gap-2">
+            <AppText className="text-3xl font-black text-white">
+              {getOrdinal(rank)}
+            </AppText>
+            <AppText
+              className="text-xs font-medium"
+              style={{ color: 'rgba(255,255,255,0.5)' }}
+            >
+              of {totalTeams} teams
+            </AppText>
+          </View>
+        </View>
+      </View>
+
+      <View
+        className="my-3 h-px w-full"
+        style={{ backgroundColor: 'rgba(255,255,255,0.1)' }}
+      />
+
+      <View className="flex-row items-center justify-between">
+        <View>
+          <AppText
+            className="text-[10px] font-semibold uppercase tracking-wider"
+            style={{ color: 'rgba(255,255,255,0.7)' }}
+          >
+            Current Score
+          </AppText>
+          <View className="mt-1 flex-row items-center gap-2">
+            <AppText className="text-2xl font-bold text-white">
+              {points.toLocaleString()}
+            </AppText>
+            <View
+              className="flex-row items-center gap-1 rounded-full px-2 py-0.5"
+              style={{ backgroundColor: 'rgba(255,255,255,0.1)' }}
+            >
+              <Feather name="trending-up" size={10} color="#4ADE80" />
+              <AppText className="text-[10px] font-semibold text-white">
+                PTS
+              </AppText>
+            </View>
+          </View>
+        </View>
+
+        {pointsToNext > 0 ? (
+          <View
+            className="flex-row items-center gap-2 rounded-xl px-3 py-2"
+            style={{ backgroundColor: 'rgba(255,255,255,0.1)' }}
+          >
+            <View
+              className="h-7 w-7 items-center justify-center rounded-full"
+              style={{ backgroundColor: 'rgba(255,255,255,0.1)' }}
+            >
+              <Feather name="arrow-up-right" size={14} color="#FFFFFF" />
+            </View>
+            <View>
+              <AppText
+                className="text-[10px] font-medium"
+                style={{ color: 'rgba(255,255,255,0.6)' }}
+              >
+                Next Rank
+              </AppText>
+              <AppText className="text-xs font-bold text-white">
+                {pointsToNext.toLocaleString()} pts to go
+              </AppText>
+            </View>
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/src/features/leaderboard/components/tiebreaker-info.tsx
+++ b/src/features/leaderboard/components/tiebreaker-info.tsx
@@ -1,0 +1,28 @@
+import Feather from '@expo/vector-icons/Feather';
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+
+export function TiebreakerInfo() {
+  return (
+    <View className="mt-4 flex-row items-start gap-2 px-1">
+      <View
+        className="h-5 w-5 items-center justify-center rounded-full"
+        style={{ backgroundColor: mflColors.surface, borderWidth: 1, borderColor: mflColors.inkLight }}
+      >
+        <Feather name="info" size={10} color={mflColors.textMuted} />
+      </View>
+      <View className="flex-1">
+        <AppText className="text-xs text-muted">
+          <AppText className="text-xs font-bold text-foreground">
+            Tiebreaker:
+          </AppText>
+          {' '}Teams with higher Avg Run Rate (RR) rank higher.
+        </AppText>
+        <AppText className="mt-1 text-[10px] text-muted">
+          When points are equal, higher RR rewards consistency and effort intensity.
+        </AppText>
+      </View>
+    </View>
+  );
+}

--- a/src/features/team/components/my-team-view-screen.tsx
+++ b/src/features/team/components/my-team-view-screen.tsx
@@ -8,6 +8,7 @@ import { ScreenState } from '../../../components/screen-state';
 import { useLeagueContext } from '../../../contexts/league-context';
 import { useRole } from '../../../contexts/role-context';
 import { useMyTeamView } from '../hooks/use-my-team-view';
+import { useTeamBalance } from '../hooks/use-team-balance';
 import { mflColors } from '../../../constants/colors';
 import {
   useLeagueSponsors,
@@ -17,6 +18,7 @@ import {
 import { TeamViewHeader } from './team-view-header';
 import { TeamViewStats } from './team-view-stats';
 import { TeamViewRoster } from './team-view-roster';
+import { TeamBalanceCard } from './team-balance-card';
 
 export function MyTeamViewScreen() {
   const { activeLeague } = useLeagueContext();
@@ -40,6 +42,7 @@ export function MyTeamViewScreen() {
 
   const { data: sponsorSlots } = useLeagueSponsors(leagueId);
   const teamSponsor = teamId ? getTeamSponsor(sponsorSlots ?? [], teamId) : null;
+  const { data: balanceData } = useTeamBalance(leagueId);
 
   const canViewTeam = isPlayer || isCaptain || isViceCaptain;
 
@@ -162,6 +165,9 @@ export function MyTeamViewScreen() {
             showRestDays={showRestDays}
           />
         )}
+
+        {/* Team Balance Score */}
+        {balanceData && <TeamBalanceCard balance={balanceData} />}
 
         {/* Roster */}
         <TeamViewRoster

--- a/src/features/team/components/team-balance-card.tsx
+++ b/src/features/team/components/team-balance-card.tsx
@@ -1,0 +1,69 @@
+import Feather from '@expo/vector-icons/Feather';
+import { View } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { BalanceBreakdownDTO } from '../types/team.dto';
+
+interface TeamBalanceCardProps {
+  balance: BalanceBreakdownDTO;
+}
+
+function BalanceBar({ label, score }: { label: string; score: number }) {
+  const color =
+    score >= 80 ? mflColors.brand : score >= 60 ? mflColors.amber : mflColors.danger;
+
+  return (
+    <View className="gap-1">
+      <View className="flex-row items-center justify-between">
+        <AppText className="text-[11px] text-muted">{label}</AppText>
+        <AppText className="text-[11px] font-semibold" style={{ color }}>
+          {Math.round(score)}%
+        </AppText>
+      </View>
+      <View className="h-1.5 w-full rounded-full" style={{ backgroundColor: mflColors.inkLight }}>
+        <View
+          className="h-1.5 rounded-full"
+          style={{ width: `${Math.min(100, Math.max(0, score))}%`, backgroundColor: color }}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function TeamBalanceCard({ balance }: TeamBalanceCardProps) {
+  const overall = Math.round(balance.overallScore);
+  const overallColor =
+    overall >= 80 ? mflColors.brand : overall >= 60 ? mflColors.amber : mflColors.danger;
+
+  return (
+    <Card className="p-4">
+      <View className="flex-row items-center gap-2 mb-3">
+        <View
+          className="h-7 w-7 items-center justify-center rounded-full"
+          style={{ backgroundColor: `${overallColor}15` }}
+        >
+          <Feather name="sliders" size={14} color={overallColor} />
+        </View>
+        <AppText className="text-sm font-bold text-foreground">
+          Team Balance
+        </AppText>
+        <View
+          className="ml-auto rounded-full px-2 py-0.5"
+          style={{ backgroundColor: `${overallColor}15` }}
+        >
+          <AppText className="text-xs font-bold" style={{ color: overallColor }}>
+            {overall}/100
+          </AppText>
+        </View>
+      </View>
+
+      <View className="gap-2">
+        <BalanceBar label="Fitness" score={balance.fitnessScore} />
+        <BalanceBar label="Gender Mix" score={balance.genderScore} />
+        <BalanceBar label="Age Distribution" score={balance.ageScore} />
+        <BalanceBar label="Department Diversity" score={balance.departmentScore} />
+      </View>
+    </Card>
+  );
+}

--- a/src/features/team/hooks/use-team-balance.ts
+++ b/src/features/team/hooks/use-team-balance.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../../core/config';
+import { fetchTeamBalance } from '../services/team.service';
+import type { BalanceBreakdownDTO } from '../types/team.dto';
+
+export function useTeamBalance(leagueId: string) {
+  return useQuery<BalanceBreakdownDTO>({
+    queryKey: queryKeys.leagues.teamBalance(leagueId),
+    queryFn: async () => {
+      const res = await fetchTeamBalance(leagueId);
+      if (!res.success) throw new Error(res.error || 'Failed to fetch balance');
+      return res.score;
+    },
+    enabled: !!leagueId,
+    staleTime: 5 * 60 * 1000, // 5 minutes — balance changes infrequently
+  });
+}

--- a/src/features/team/index.ts
+++ b/src/features/team/index.ts
@@ -5,4 +5,5 @@ export { useMyTeamView } from './hooks/use-my-team-view';
 export { useUnallocatedMembers } from './hooks/use-unallocated-members';
 export { useAssignMember } from './hooks/use-assign-member';
 export { useTeamSubmissions } from './hooks/use-team-submissions';
+export { useTeamBalance } from './hooks/use-team-balance';
 export type { LeagueMember, Team, TeamMember, MyTeamStats, TeamViewStats, TeamViewData } from './types/team.model';

--- a/src/features/team/services/team.service.ts
+++ b/src/features/team/services/team.service.ts
@@ -1,5 +1,5 @@
 import { api } from '../../../core/api';
-import type { LeagueMembersResponseDTO, TeamsResponseDTO, TeamMembersResponseDTO, TeamSummaryResponseDTO } from '../types/team.dto';
+import type { LeagueMembersResponseDTO, TeamsResponseDTO, TeamMembersResponseDTO, TeamSummaryResponseDTO, TeamBalanceResponseDTO } from '../types/team.dto';
 
 export async function fetchLeagueMembers(leagueId: string): Promise<LeagueMembersResponseDTO> {
   const res = await api.get<LeagueMembersResponseDTO>(`/api/leagues/${leagueId}/members`);
@@ -38,5 +38,14 @@ export async function assignMemberToTeam(
   const res = await api.post(`/api/leagues/${leagueId}/teams/${teamId}/members`, {
     league_member_id: leagueMemberId,
   });
+  return res.data;
+}
+
+export async function fetchTeamBalance(
+  leagueId: string,
+): Promise<TeamBalanceResponseDTO> {
+  const res = await api.get<TeamBalanceResponseDTO>(
+    `/api/leagues/${leagueId}/balance`,
+  );
   return res.data;
 }

--- a/src/features/team/types/index.ts
+++ b/src/features/team/types/index.ts
@@ -1,2 +1,2 @@
-export type { LeagueMemberDTO, LeagueMembersResponseDTO, TeamDTO, TeamsResponseDTO, TeamMemberDTO, TeamMembersResponseDTO, TeamSummaryDTO, TeamSummaryResponseDTO } from './team.dto';
+export type { LeagueMemberDTO, LeagueMembersResponseDTO, TeamDTO, TeamsResponseDTO, TeamMemberDTO, TeamMembersResponseDTO, TeamSummaryDTO, TeamSummaryResponseDTO, BalanceBreakdownDTO, TeamBalanceResponseDTO } from './team.dto';
 export type { LeagueMember, Team, TeamMember, MyTeamStats, TeamViewStats, TeamViewData } from './team.model';

--- a/src/features/team/types/team.dto.ts
+++ b/src/features/team/types/team.dto.ts
@@ -73,3 +73,18 @@ export interface TeamSummaryResponseDTO {
   success: boolean;
   data: TeamSummaryDTO;
 }
+
+// GET /api/leagues/[id]/balance
+export interface BalanceBreakdownDTO {
+  fitnessScore: number;
+  genderScore: number;
+  ageScore: number;
+  departmentScore: number;
+  overallScore: number;
+}
+
+export interface TeamBalanceResponseDTO {
+  success: boolean;
+  score: BalanceBreakdownDTO;
+  error?: string;
+}


### PR DESCRIPTION
## Summary
- Add RankBanner showing user's team rank, score, and points-to-next-rank on Overall tab
- Add TiebreakerInfo explaining RR as tiebreaker (conditionally shown when RR enabled)
- Add TeamBalanceCard with fitness/gender/age/department breakdown bars in team view
- New service + hook for GET /api/leagues/[id]/balance endpoint

## Test plan
- [ ] Verify rank banner appears on leaderboard Overall tab when user has a team
- [ ] Verify tiebreaker info shows below team standings when RR formula is 'standard'
- [ ] Verify team balance card renders in My Team view with correct breakdown scores
- [ ] Verify no regression on challenge tab or points-only leagues (RR hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)