### PR TITLE
feat: anti-cheat OCR plausibility display for mobile (#156)

### DIFF
--- a/src/app/(app)/submission-detail.tsx
+++ b/src/app/(app)/submission-detail.tsx
@@ -325,6 +325,14 @@ export default function SubmissionDetailScreen() {
               <MetricRow icon="target" label="Holes" value={submission.holes} />
             </View>
           </View>
+          <View className="flex-row gap-3">
+            <View className="flex-1">
+              <MetricRow icon="heart" label="Avg HR" value={submission.hrAvg} unit="bpm" />
+            </View>
+            <View className="flex-1">
+              <MetricRow icon="zap" label="Calories" value={submission.caloriesBurned} unit="kcal" />
+            </View>
+          </View>
         </View>
       )}
 
@@ -412,6 +420,43 @@ export default function SubmissionDetailScreen() {
           </View>
         )}
       </View>
+
+      {/* Plausibility Details */}
+      {submission.plausibilityScore != null && (
+        <View className="gap-2">
+          <AppText className="text-sm font-medium text-foreground">Plausibility Details</AppText>
+          <View
+            className="p-3 rounded-lg"
+            style={{
+              backgroundColor: submission.plausibilityScore < 50 ? mflColors.dangerLight : mflColors.surface,
+              borderWidth: 1,
+              borderColor: submission.plausibilityScore < 50 ? mflColors.danger + '30' : mflColors.border,
+            }}
+          >
+            <View className="flex-row items-center justify-between mb-2">
+              <AppText className="text-sm font-semibold text-foreground">Plausibility Score</AppText>
+              <View
+                className="px-2.5 py-0.5 rounded-full"
+                style={{
+                  backgroundColor: submission.plausibilityScore < 50 ? mflColors.danger : mflColors.brand,
+                }}
+              >
+                <AppText className="text-[10px] font-bold" style={{ color: '#fff' }}>
+                  {submission.plausibilityScore}/100
+                </AppText>
+              </View>
+            </View>
+            {submission.plausibilityReason ? (
+              <AppText className="text-xs text-muted">{submission.plausibilityReason}</AppText>
+            ) : null}
+            {(submission.reviewTier === 'captain' || submission.reviewTier === 'governor') ? (
+              <AppText className="text-xs font-semibold mt-2" style={{ color: mflColors.danger }}>
+                Flagged for {submission.reviewTier} review
+              </AppText>
+            ) : null}
+          </View>
+        </View>
+      )}
 
       {/* Notes */}
       {submission.notes && !isExemption && (

--- a/src/app/(app)/submission-validation.tsx
+++ b/src/app/(app)/submission-validation.tsx
@@ -53,6 +53,7 @@ export default function SubmissionValidationScreen() {
   const [rejectionType, setRejectionType] = useState<RejectionType>('rejected_resubmit');
   const [rejectionReason, setRejectionReason] = useState('');
   const [suspiciousProof, setSuspiciousProof] = useState(false);
+  const [reviewerNotes, setReviewerNotes] = useState('');
   const [validatingId, setValidatingId] = useState<SubmissionId | null>(null);
 
   const data = submissionsQuery.data;
@@ -102,7 +103,7 @@ export default function SubmissionValidationScreen() {
     (
       submission: SubmissionForValidation,
       status: ValidateSubmissionRequestDTO['status'],
-      options?: { rejectionReason?: string; suspiciousProof?: boolean },
+      options?: { rejectionReason?: string; suspiciousProof?: boolean; reviewerNotes?: string },
     ) => {
       if (!leagueId) return;
 
@@ -120,6 +121,9 @@ export default function SubmissionValidationScreen() {
         }
         dataToSend.rejection_reason = reason;
         dataToSend.suspicious_proof = options?.suspiciousProof ?? false;
+        if (options?.reviewerNotes?.trim()) {
+          dataToSend.reviewer_notes = options.reviewerNotes.trim();
+        }
       }
 
       setValidatingId(submission.id);
@@ -135,6 +139,7 @@ export default function SubmissionValidationScreen() {
             setRejectSubmission(null);
             setRejectionReason('');
             setSuspiciousProof(false);
+            setReviewerNotes('');
             Alert.alert(
               status === 'approved' ? 'Submission Approved' : 'Submission Rejected',
               status === 'approved'
@@ -167,6 +172,7 @@ export default function SubmissionValidationScreen() {
     setRejectionType('rejected_resubmit');
     setRejectionReason('');
     setSuspiciousProof(false);
+    setReviewerNotes('');
   }, []);
 
   const confirmReject = useCallback(() => {
@@ -174,8 +180,9 @@ export default function SubmissionValidationScreen() {
     submitValidation(rejectSubmission, rejectionType, {
       rejectionReason,
       suspiciousProof,
+      reviewerNotes,
     });
-  }, [rejectSubmission, rejectionReason, rejectionType, submitValidation, suspiciousProof]);
+  }, [rejectSubmission, rejectionReason, rejectionType, reviewerNotes, submitValidation, suspiciousProof]);
 
   if (!activeLeague) {
     return (
@@ -293,10 +300,13 @@ export default function SubmissionValidationScreen() {
             rejectionType={rejectionType}
             rejectionReason={rejectionReason}
             suspiciousProof={suspiciousProof}
+            reviewerNotes={reviewerNotes}
+            isPrivileged={isHost || isGovernor}
             isValidating={String(validatingId) === String(rejectSubmission.id)}
             onTypeChange={setRejectionType}
             onReasonChange={setRejectionReason}
             onSuspiciousProofChange={setSuspiciousProof}
+            onReviewerNotesChange={setReviewerNotes}
             onCancel={() => setRejectSubmission(null)}
             onConfirm={confirmReject}
           />

--- a/src/features/submissions/mappers/submission.mapper.ts
+++ b/src/features/submissions/mappers/submission.mapper.ts
@@ -26,6 +26,12 @@ export function toSubmissionEntry(dto: SubmissionEntryDTO): SubmissionEntry {
     customFieldValue: dto.custom_field_value ?? null,
     customFieldValue2: dto.custom_field_value_2 ?? null,
     outcome: dto.outcome ?? null,
+    hrAvg: dto.hr_avg ?? null,
+    caloriesBurned: dto.calories_burned ?? null,
+    plausibilityScore: dto.plausibility_score ?? null,
+    reviewTier: dto.review_tier ?? null,
+    plausibilityReason: dto.plausibility_reason ?? null,
+    reviewerNotes: dto.reviewer_notes ?? null,
   };
 }
 
@@ -35,6 +41,10 @@ export function toMySubmissionsData(dto: MySubmissionsResponseDTO): MySubmission
     stats: dto.data.stats,
     leagueMemberId: dto.data.leagueMemberId,
     teamId: dto.data.teamId,
+    suspiciousProofStrikes: dto.data.suspiciousProofStrikes ?? 0,
+    suspiciousProofLastStrikeAt: dto.data.suspiciousProofLastStrikeAt ?? null,
+    suspiciousProofWarningThreshold: dto.data.suspiciousProofWarningThreshold ?? 2,
+    suspiciousProofRejectionThreshold: dto.data.suspiciousProofRejectionThreshold ?? 3,
   };
 }
 

--- a/src/features/submissions/types/submission.dto.ts
+++ b/src/features/submissions/types/submission.dto.ts
@@ -26,6 +26,12 @@ export interface SubmissionEntryDTO {
   custom_field_value?: string | null;
   custom_field_value_2?: string | null;
   outcome?: string | null;
+  hr_avg?: number | null;
+  calories_burned?: number | null;
+  plausibility_score?: number | null;
+  review_tier?: 'none' | 'captain' | 'governor' | null;
+  plausibility_reason?: string | null;
+  reviewer_notes?: string | null;
 }
 
 export interface SubmissionStatsDTO {

--- a/src/features/submissions/types/submission.model.ts
+++ b/src/features/submissions/types/submission.model.ts
@@ -22,6 +22,12 @@ export interface SubmissionEntry {
   customFieldValue?: string | null;
   customFieldValue2?: string | null;
   outcome?: string | null;
+  hrAvg?: number | null;
+  caloriesBurned?: number | null;
+  plausibilityScore?: number | null;
+  reviewTier?: 'none' | 'captain' | 'governor' | null;
+  plausibilityReason?: string | null;
+  reviewerNotes?: string | null;
 }
 
 export interface SubmissionStats {
@@ -36,6 +42,10 @@ export interface MySubmissionsData {
   stats: SubmissionStats;
   leagueMemberId: string;
   teamId: string | null;
+  suspiciousProofStrikes: number;
+  suspiciousProofLastStrikeAt: string | null;
+  suspiciousProofWarningThreshold: number;
+  suspiciousProofRejectionThreshold: number;
 }
 
 export interface RRPreview {

--- a/src/features/team/mappers/team-submission.mapper.ts
+++ b/src/features/team/mappers/team-submission.mapper.ts
@@ -26,6 +26,12 @@ function toSubmissionForValidation(dto: TeamSubmissionDTO): SubmissionForValidat
     modifiedDate: dto.modified_date,
     reuploadOf: dto.reupload_of,
     outcome: dto.outcome ?? null,
+    hrAvg: dto.hr_avg ?? null,
+    caloriesBurned: dto.calories_burned ?? null,
+    plausibilityScore: dto.plausibility_score ?? null,
+    reviewTier: dto.review_tier ?? null,
+    plausibilityReason: dto.plausibility_reason ?? null,
+    reviewerNotes: dto.reviewer_notes ?? null,
     member: {
       userId: dto.member.user_id,
       username: dto.member.username,

--- a/src/features/team/types/team-submission.dto.ts
+++ b/src/features/team/types/team-submission.dto.ts
@@ -27,6 +27,12 @@ export interface TeamSubmissionDTO {
   custom_field_value_2?: string | null;
   outcome?: string | null;
   rejection_reason?: string | null;
+  hr_avg?: number | null;
+  calories_burned?: number | null;
+  plausibility_score?: number | null;
+  review_tier?: 'none' | 'captain' | 'governor' | null;
+  plausibility_reason?: string | null;
+  reviewer_notes?: string | null;
   member: {
     user_id: string;
     username: string;

--- a/src/features/validation/components/reject-submission-panel.tsx
+++ b/src/features/validation/components/reject-submission-panel.tsx
@@ -26,10 +26,13 @@ interface RejectSubmissionPanelProps {
   rejectionType: RejectionType;
   rejectionReason: string;
   suspiciousProof: boolean;
+  reviewerNotes?: string;
+  isPrivileged?: boolean;
   isValidating: boolean;
   onTypeChange: (value: RejectionType) => void;
   onReasonChange: (value: string) => void;
   onSuspiciousProofChange: (value: boolean) => void;
+  onReviewerNotesChange?: (value: string) => void;
   onCancel: () => void;
   onConfirm: () => void;
 }
@@ -39,10 +42,13 @@ export function RejectSubmissionPanel({
   rejectionType,
   rejectionReason,
   suspiciousProof,
+  reviewerNotes = '',
+  isPrivileged = false,
   isValidating,
   onTypeChange,
   onReasonChange,
   onSuspiciousProofChange,
+  onReviewerNotesChange,
   onCancel,
   onConfirm,
 }: RejectSubmissionPanelProps) {
@@ -112,6 +118,22 @@ export function RejectSubmissionPanel({
           </AppText>
         </View>
       </Pressable>
+
+      {isPrivileged && onReviewerNotesChange ? (
+        <View className="gap-2">
+          <AppText className="text-xs font-semibold text-muted uppercase">
+            Reviewer Notes (Internal Only)
+          </AppText>
+          <TextInput
+            style={{ ...reasonInputStyle, minHeight: 64 }}
+            value={reviewerNotes}
+            onChangeText={onReviewerNotesChange}
+            placeholder="Internal notes visible only to host/governor..."
+            placeholderTextColor={mflColors.textMuted}
+            multiline
+          />
+        </View>
+      ) : null}
 
       {isPermanent ? (
         <View className="rounded-xl p-3" style={{ backgroundColor: mflColors.dangerLight }}>

--- a/src/features/validation/components/submission-detail-panel.tsx
+++ b/src/features/validation/components/submission-detail-panel.tsx
@@ -135,6 +135,56 @@ export function SubmissionDetailPanel({
         </View>
       ) : null}
 
+      {submission.plausibilityScore != null ? (
+        <View
+          className="rounded-xl p-3 gap-2"
+          style={{
+            backgroundColor: submission.plausibilityScore < 50 ? mflColors.dangerLight : mflColors.surface,
+            borderWidth: 1,
+            borderColor: submission.plausibilityScore < 50 ? mflColors.danger + '30' : mflColors.border,
+          }}
+        >
+          <View className="flex-row items-center justify-between">
+            <AppText className="text-xs font-semibold text-foreground">Plausibility Score</AppText>
+            <View
+              className="px-2.5 py-0.5 rounded-full"
+              style={{
+                backgroundColor: submission.plausibilityScore < 50 ? mflColors.danger : mflColors.brand,
+              }}
+            >
+              <AppText className="text-[10px] font-bold" style={{ color: '#fff' }}>
+                {submission.plausibilityScore}/100
+              </AppText>
+            </View>
+          </View>
+          {submission.plausibilityReason ? (
+            <AppText className="text-xs text-muted">{submission.plausibilityReason}</AppText>
+          ) : null}
+          {(submission.reviewTier === 'captain' || submission.reviewTier === 'governor') ? (
+            <AppText className="text-xs font-semibold" style={{ color: mflColors.danger }}>
+              Flagged for {submission.reviewTier} review
+            </AppText>
+          ) : null}
+        </View>
+      ) : null}
+
+      {submission.reviewerNotes ? (
+        <View
+          className="rounded-xl p-3"
+          style={{ backgroundColor: mflColors.amberLight, borderWidth: 1, borderColor: mflColors.amber + '30' }}
+        >
+          <View className="flex-row items-center gap-1.5 mb-1">
+            <Feather name="shield" size={14} color={mflColors.amber} />
+            <AppText className="text-[10px] font-bold uppercase" style={{ color: mflColors.amber }}>
+              Reviewer Notes (Internal)
+            </AppText>
+          </View>
+          <AppText className="text-xs" style={{ color: mflColors.amber }}>
+            {submission.reviewerNotes}
+          </AppText>
+        </View>
+      ) : null}
+
       {submission.rejectionReason ? (
         <View className="rounded-xl p-3" style={{ backgroundColor: mflColors.dangerLight }}>
           <AppText className="text-xs font-semibold" style={{ color: mflColors.danger }}>

--- a/src/features/validation/components/submission-validation-card.tsx
+++ b/src/features/validation/components/submission-validation-card.tsx
@@ -138,6 +138,21 @@ export function SubmissionValidationCard({
         </Pressable>
       ) : null}
 
+      {submission.plausibilityScore != null && submission.plausibilityScore < 50 ? (
+        <View
+          className="flex-row items-center gap-2 rounded-xl px-3 py-2"
+          style={{ backgroundColor: mflColors.dangerLight }}
+        >
+          <Feather name="alert-triangle" size={14} color={mflColors.danger} />
+          <AppText className="text-[10px] font-semibold flex-1" style={{ color: mflColors.danger }}>
+            Plausibility {submission.plausibilityScore}/100
+            {submission.reviewTier && submission.reviewTier !== 'none'
+              ? ` · Flagged for ${submission.reviewTier}`
+              : ''}
+          </AppText>
+        </View>
+      ) : null}
+
       {submission.notes ? (
         <View className="rounded-xl p-3 bg-default-100">
           <AppText className="text-[10px] font-semibold text-muted uppercase">Notes</AppText>

--- a/src/features/validation/mappers/validation.mapper.ts
+++ b/src/features/validation/mappers/validation.mapper.ts
@@ -23,6 +23,12 @@ function toSubmissionForValidation(dto: SubmissionForValidationDTO): SubmissionF
     modifiedDate: dto.modified_date,
     reuploadOf: dto.reupload_of,
     outcome: dto.outcome ?? null,
+    hrAvg: dto.hr_avg ?? null,
+    caloriesBurned: dto.calories_burned ?? null,
+    plausibilityScore: dto.plausibility_score ?? null,
+    reviewTier: dto.review_tier ?? null,
+    plausibilityReason: dto.plausibility_reason ?? null,
+    reviewerNotes: dto.reviewer_notes ?? null,
     member: {
       userId: dto.member.user_id,
       username: dto.member.username,

--- a/src/features/validation/types/validation.dto.ts
+++ b/src/features/validation/types/validation.dto.ts
@@ -28,6 +28,12 @@ export interface SubmissionForValidationDTO {
   modified_date: string | null;
   reupload_of: SubmissionIdDTO | null;
   outcome?: string | null;
+  hr_avg?: number | null;
+  calories_burned?: number | null;
+  plausibility_score?: number | null;
+  review_tier?: 'none' | 'captain' | 'governor' | null;
+  plausibility_reason?: string | null;
+  reviewer_notes?: string | null;
   member: {
     user_id: string;
     username: string;
@@ -63,6 +69,7 @@ export interface SubmissionsResponseDTO {
 export interface ValidateSubmissionRequestDTO {
   status: 'approved' | 'rejected' | 'rejected_resubmit' | 'rejected_permanent';
   rejection_reason?: string;
+  reviewer_notes?: string;
   awarded_points?: number;
   suspicious_proof?: boolean;
 }

--- a/src/features/validation/types/validation.model.ts
+++ b/src/features/validation/types/validation.model.ts
@@ -36,6 +36,12 @@ export interface SubmissionForValidation {
   modifiedDate: string | null;
   reuploadOf: SubmissionId | null;
   outcome: string | null;
+  hrAvg: number | null;
+  caloriesBurned: number | null;
+  plausibilityScore: number | null;
+  reviewTier: 'none' | 'captain' | 'governor' | null;
+  plausibilityReason: string | null;
+  reviewerNotes: string | null;
   member: SubmissionMember;
 }
 

--- a/src/features/validation/utils/validation-utils.ts
+++ b/src/features/validation/utils/validation-utils.ts
@@ -111,6 +111,8 @@ export function getSubmissionMetrics(submission: SubmissionForValidation) {
     { label: 'Distance', value: formatMetric(submission.distance, 'km') },
     { label: 'Steps', value: formatMetric(submission.steps, 'steps') },
     { label: 'Holes', value: formatMetric(submission.holes, 'holes') },
+    { label: 'Avg HR', value: formatMetric(submission.hrAvg, 'bpm') },
+    { label: 'Calories', value: formatMetric(submission.caloriesBurned, 'kcal') },
   ].filter((metric): metric is { label: string; value: string } => Boolean(metric.value));
 }
 


### PR DESCRIPTION
## Summary
- Surface `plausibility_score`, `review_tier`, `plausibility_reason`, `hr_avg`, `calories_burned`, `reviewer_notes`, and suspicious proof strike thresholds across all submission layers (DTOs, models, mappers, UI)
- Player submission detail now shows plausibility score badge, reason, review tier flag, HR, and calories
- Host/Governor validation cards show plausibility alert for flagged submissions (score < 50)
- Validation detail panel shows full plausibility section + reviewer notes (internal only)
- Reject panel adds reviewer notes input for host/governor
- 14 files changed, 0 new TS errors

## Test plan
- [ ] Submit a workout with extreme values (e.g. 500km run in 10min) → verify plausibility score < 50 appears on submission detail
- [ ] Open validation screen as host/governor → verify flagged submissions show plausibility alert badge
- [ ] Tap into a flagged submission detail → verify score, reason, review tier displayed
- [ ] Reject a submission with suspicious proof checked + reviewer notes → verify notes sent to API
- [ ] Verify HR and calories metrics render when returned by backend