### PR TITLE
feat: improve reaction emoji UI with overlapped layout and hidden picker

### DIFF
--- a/src/features/messaging/components/chat-message-bubble.tsx
+++ b/src/features/messaging/components/chat-message-bubble.tsx
@@ -36,6 +36,7 @@ export function ChatMessageBubble({
   onOpenDeepLink,
 }: ChatMessageBubbleProps) {
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
   const isSystem = message.messageType === 'system';
   const isCaptainBoost =
@@ -83,34 +84,87 @@ export function ChatMessageBubble({
         </Pressable>
 
         {message.reactions.length > 0 ? (
-          <View className="mt-1 flex-row flex-wrap gap-1">
-            {message.reactions.map((reaction) => (
-              <MessagingChip
-                key={reaction.emoji}
-                label={`${reaction.emoji} ${reaction.userIds.length}`}
-                selected={!!currentUserId && reaction.userIds.includes(currentUserId)}
-                onPress={() => onReact(message.messageId, reaction.emoji)}
-              />
-            ))}
+          <View className="mt-1 flex-row items-center">
+            {message.reactions.map((reaction, index) => {
+              const isUserReaction = !!currentUserId && reaction.userIds.includes(currentUserId);
+              return (
+                <Pressable
+                  key={reaction.emoji}
+                  onPress={() => onReact(message.messageId, reaction.emoji)}
+                  className="items-center justify-center rounded-full"
+                  style={{
+                    backgroundColor: isUserReaction ? '#FFFFFF' : mflColors.card,
+                    borderWidth: isUserReaction ? 0 : 2,
+                    borderColor: mflColors.surface,
+                    width: 32,
+                    height: 32,
+                    marginLeft: index > 0 ? -8 : 0,
+                    zIndex: message.reactions.length - index,
+                    shadowColor: '#000',
+                    shadowOffset: { width: 0, height: 1 },
+                    shadowOpacity: 0.1,
+                    shadowRadius: 2,
+                    elevation: 2,
+                  }}
+                >
+                  <AppText className="text-base">{reaction.emoji}</AppText>
+                  {reaction.userIds.length > 1 ? (
+                    <View
+                      className="absolute -bottom-1 -right-1 items-center justify-center rounded-full"
+                      style={{
+                        backgroundColor: isUserReaction ? mflColors.brand : mflColors.surface,
+                        borderWidth: 1.5,
+                        borderColor: mflColors.surface,
+                        minWidth: 16,
+                        height: 16,
+                        paddingHorizontal: 3,
+                      }}
+                    >
+                      <AppText 
+                        className="text-[9px] font-bold"
+                        style={{ 
+                          color: isUserReaction ? mflColors.white : mflColors.text
+                        }}
+                      >
+                        {reaction.userIds.length}
+                      </AppText>
+                    </View>
+                  ) : null}
+                </Pressable>
+              );
+            })}
           </View>
         ) : null}
 
         <View className="mt-1 flex-row flex-wrap gap-1">
           <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
-          {QUICK_EMOJIS.map((emoji) => (
-            <MessagingChip
-              key={emoji}
-              label={emoji}
-              selected={message.reactions.some(
-                (reaction) =>
-                  reaction.emoji === emoji &&
-                  !!currentUserId &&
-                  reaction.userIds.includes(currentUserId),
-              )}
-              onPress={() => onReact(message.messageId, emoji)}
-            />
-          ))}
+          <MessagingChip 
+            label="React" 
+            icon="plus" 
+            onPress={() => setShowEmojiPicker(!showEmojiPicker)} 
+          />
         </View>
+
+        {showEmojiPicker ? (
+          <View className="mt-1 flex-row flex-wrap gap-1">
+            {QUICK_EMOJIS.map((emoji) => (
+              <MessagingChip
+                key={emoji}
+                label={emoji}
+                selected={message.reactions.some(
+                  (reaction) =>
+                    reaction.emoji === emoji &&
+                    !!currentUserId &&
+                    reaction.userIds.includes(currentUserId),
+                )}
+                onPress={() => {
+                  onReact(message.messageId, emoji);
+                  setShowEmojiPicker(false);
+                }}
+              />
+            ))}
+          </View>
+        ) : null}
       </View>
     );
   }
@@ -320,31 +374,90 @@ export function ChatMessageBubble({
         </Pressable>
       </View>
 
+      {/* Reactions display - overlapped style */}
+      {message.reactions.length > 0 ? (
+        <View 
+          className={`mb-2 flex-row items-center ${isOwn ? 'justify-end' : 'justify-start'}`}
+          style={{ marginLeft: isOwn ? 0 : 36 }}
+        >
+          {message.reactions.map((reaction, index) => {
+            const isUserReaction = !!currentUserId && reaction.userIds.includes(currentUserId);
+            return (
+              <Pressable
+                key={reaction.emoji}
+                onPress={() => onReact(message.messageId, reaction.emoji)}
+                className="items-center justify-center rounded-full"
+                style={{
+                  backgroundColor: isUserReaction ? '#FFFFFF' : mflColors.card,
+                  borderWidth: isUserReaction ? 0 : 2,
+                  borderColor: mflColors.surface,
+                  width: 32,
+                  height: 32,
+                  marginLeft: index > 0 ? -8 : 0,
+                  zIndex: message.reactions.length - index,
+                  shadowColor: '#000',
+                  shadowOffset: { width: 0, height: 1 },
+                  shadowOpacity: 0.1,
+                  shadowRadius: 2,
+                  elevation: 2,
+                }}
+              >
+                <AppText className="text-base">{reaction.emoji}</AppText>
+                {reaction.userIds.length > 1 ? (
+                  <View
+                    className="absolute -bottom-1 -right-1 items-center justify-center rounded-full"
+                    style={{
+                      backgroundColor: isUserReaction ? mflColors.brand : mflColors.surface,
+                      borderWidth: 1.5,
+                      borderColor: mflColors.surface,
+                      minWidth: 16,
+                      height: 16,
+                      paddingHorizontal: 3,
+                    }}
+                  >
+                    <AppText 
+                      className="text-[9px] font-bold"
+                      style={{ 
+                        color: isUserReaction ? mflColors.white : mflColors.text
+                      }}
+                    >
+                      {reaction.userIds.length}
+                    </AppText>
+                  </View>
+                ) : null}
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+
+      {/* Action buttons - Reply and React */}
       <View className={`mb-2 flex-row flex-wrap gap-1 ${isOwn ? 'justify-end' : 'justify-start'}`}>
         <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
-        {QUICK_EMOJIS.map((emoji) => (
-          <MessagingChip
-            key={emoji}
-            label={emoji}
-            selected={message.reactions.some(
-              (reaction) =>
-                reaction.emoji === emoji &&
-                !!currentUserId &&
-                reaction.userIds.includes(currentUserId),
-            )}
-            onPress={() => onReact(message.messageId, emoji)}
-          />
-        ))}
+        <MessagingChip 
+          label="React" 
+          icon="plus" 
+          onPress={() => setShowEmojiPicker(!showEmojiPicker)} 
+        />
       </View>
 
-      {message.reactions.length > 0 ? (
+      {/* Emoji picker - shown when React button is pressed */}
+      {showEmojiPicker ? (
         <View className={`mb-2 flex-row flex-wrap gap-1 ${isOwn ? 'justify-end' : 'justify-start'}`}>
-          {message.reactions.map((reaction) => (
+          {QUICK_EMOJIS.map((emoji) => (
             <MessagingChip
-              key={reaction.emoji}
-              label={`${reaction.emoji} ${reaction.userIds.length}`}
-              selected={!!currentUserId && reaction.userIds.includes(currentUserId)}
-              onPress={() => onReact(message.messageId, reaction.emoji)}
+              key={emoji}
+              label={emoji}
+              selected={message.reactions.some(
+                (reaction) =>
+                  reaction.emoji === emoji &&
+                  !!currentUserId &&
+                  reaction.userIds.includes(currentUserId),
+              )}
+              onPress={() => {
+                onReact(message.messageId, emoji);
+                setShowEmojiPicker(false);
+              }}
             />
           ))}
         </View>

--- a/src/features/messaging/components/chat-message-bubble.tsx
+++ b/src/features/messaging/components/chat-message-bubble.tsx
@@ -1,6 +1,14 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useState } from 'react';
-import { Dimensions, Image, Modal, Pressable, View } from 'react-native';
+import {
+  Dimensions,
+  Image,
+  Modal,
+  Pressable,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 
 import { AppText } from '../../../components/app-text';
 import { mflColors } from '../../../constants/colors';
@@ -83,88 +91,15 @@ export function ChatMessageBubble({
           </View>
         </Pressable>
 
-        {message.reactions.length > 0 ? (
-          <View className="mt-1 flex-row items-center">
-            {message.reactions.map((reaction, index) => {
-              const isUserReaction = !!currentUserId && reaction.userIds.includes(currentUserId);
-              return (
-                <Pressable
-                  key={reaction.emoji}
-                  onPress={() => onReact(message.messageId, reaction.emoji)}
-                  className="items-center justify-center rounded-full"
-                  style={{
-                    backgroundColor: isUserReaction ? '#FFFFFF' : mflColors.card,
-                    borderWidth: isUserReaction ? 0 : 2,
-                    borderColor: mflColors.surface,
-                    width: 32,
-                    height: 32,
-                    marginLeft: index > 0 ? -8 : 0,
-                    zIndex: message.reactions.length - index,
-                    shadowColor: '#000',
-                    shadowOffset: { width: 0, height: 1 },
-                    shadowOpacity: 0.1,
-                    shadowRadius: 2,
-                    elevation: 2,
-                  }}
-                >
-                  <AppText className="text-base">{reaction.emoji}</AppText>
-                  {reaction.userIds.length > 1 ? (
-                    <View
-                      className="absolute -bottom-1 -right-1 items-center justify-center rounded-full"
-                      style={{
-                        backgroundColor: isUserReaction ? mflColors.brand : mflColors.surface,
-                        borderWidth: 1.5,
-                        borderColor: mflColors.surface,
-                        minWidth: 16,
-                        height: 16,
-                        paddingHorizontal: 3,
-                      }}
-                    >
-                      <AppText 
-                        className="text-[9px] font-bold"
-                        style={{ 
-                          color: isUserReaction ? mflColors.white : mflColors.text
-                        }}
-                      >
-                        {reaction.userIds.length}
-                      </AppText>
-                    </View>
-                  ) : null}
-                </Pressable>
-              );
-            })}
-          </View>
-        ) : null}
-
-        <View className="mt-1 flex-row flex-wrap gap-1">
-          <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
-          <MessagingChip 
-            label="React" 
-            icon="plus" 
-            onPress={() => setShowEmojiPicker(!showEmojiPicker)} 
-          />
-        </View>
-
-        {showEmojiPicker ? (
-          <View className="mt-1 flex-row flex-wrap gap-1">
-            {QUICK_EMOJIS.map((emoji) => (
-              <MessagingChip
-                key={emoji}
-                label={emoji}
-                selected={message.reactions.some(
-                  (reaction) =>
-                    reaction.emoji === emoji &&
-                    !!currentUserId &&
-                    reaction.userIds.includes(currentUserId),
-                )}
-                onPress={() => {
-                  onReact(message.messageId, emoji);
-                  setShowEmojiPicker(false);
-                }}
-              />
-            ))}
-          </View>
-        ) : null}
+        <MessageActions
+          message={message}
+          currentUserId={currentUserId}
+          isCaptainBoost
+          showEmojiPicker={showEmojiPicker}
+          onReply={onReply}
+          onReact={onReact}
+          onToggleEmojiPicker={() => setShowEmojiPicker(!showEmojiPicker)}
+        />
       </View>
     );
   }
@@ -374,94 +309,15 @@ export function ChatMessageBubble({
         </Pressable>
       </View>
 
-      {/* Reactions display - overlapped style */}
-      {message.reactions.length > 0 ? (
-        <View 
-          className={`mb-2 flex-row items-center ${isOwn ? 'justify-end' : 'justify-start'}`}
-          style={{ marginLeft: isOwn ? 0 : 36 }}
-        >
-          {message.reactions.map((reaction, index) => {
-            const isUserReaction = !!currentUserId && reaction.userIds.includes(currentUserId);
-            return (
-              <Pressable
-                key={reaction.emoji}
-                onPress={() => onReact(message.messageId, reaction.emoji)}
-                className="items-center justify-center rounded-full"
-                style={{
-                  backgroundColor: isUserReaction ? '#FFFFFF' : mflColors.card,
-                  borderWidth: isUserReaction ? 0 : 2,
-                  borderColor: mflColors.surface,
-                  width: 32,
-                  height: 32,
-                  marginLeft: index > 0 ? -8 : 0,
-                  zIndex: message.reactions.length - index,
-                  shadowColor: '#000',
-                  shadowOffset: { width: 0, height: 1 },
-                  shadowOpacity: 0.1,
-                  shadowRadius: 2,
-                  elevation: 2,
-                }}
-              >
-                <AppText className="text-base">{reaction.emoji}</AppText>
-                {reaction.userIds.length > 1 ? (
-                  <View
-                    className="absolute -bottom-1 -right-1 items-center justify-center rounded-full"
-                    style={{
-                      backgroundColor: isUserReaction ? mflColors.brand : mflColors.surface,
-                      borderWidth: 1.5,
-                      borderColor: mflColors.surface,
-                      minWidth: 16,
-                      height: 16,
-                      paddingHorizontal: 3,
-                    }}
-                  >
-                    <AppText 
-                      className="text-[9px] font-bold"
-                      style={{ 
-                        color: isUserReaction ? mflColors.white : mflColors.text
-                      }}
-                    >
-                      {reaction.userIds.length}
-                    </AppText>
-                  </View>
-                ) : null}
-              </Pressable>
-            );
-          })}
-        </View>
-      ) : null}
-
-      {/* Action buttons - Reply and React */}
-      <View className={`mb-2 flex-row flex-wrap gap-1 ${isOwn ? 'justify-end' : 'justify-start'}`}>
-        <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
-        <MessagingChip 
-          label="React" 
-          icon="plus" 
-          onPress={() => setShowEmojiPicker(!showEmojiPicker)} 
-        />
-      </View>
-
-      {/* Emoji picker - shown when React button is pressed */}
-      {showEmojiPicker ? (
-        <View className={`mb-2 flex-row flex-wrap gap-1 ${isOwn ? 'justify-end' : 'justify-start'}`}>
-          {QUICK_EMOJIS.map((emoji) => (
-            <MessagingChip
-              key={emoji}
-              label={emoji}
-              selected={message.reactions.some(
-                (reaction) =>
-                  reaction.emoji === emoji &&
-                  !!currentUserId &&
-                  reaction.userIds.includes(currentUserId),
-              )}
-              onPress={() => {
-                onReact(message.messageId, emoji);
-                setShowEmojiPicker(false);
-              }}
-            />
-          ))}
-        </View>
-      ) : null}
+      <MessageActions
+        message={message}
+        currentUserId={currentUserId}
+        isOwn={isOwn}
+        showEmojiPicker={showEmojiPicker}
+        onReply={onReply}
+        onReact={onReact}
+        onToggleEmojiPicker={() => setShowEmojiPicker(!showEmojiPicker)}
+      />
 
       {/* Photo lightbox */}
       {message.photoUrl ? (
@@ -495,6 +351,133 @@ export function ChatMessageBubble({
         </Modal>
       ) : null}
     </View>
+  );
+}
+
+function ChatMessageReactions({
+  messageId,
+  reactions,
+  currentUserId,
+  onReact,
+  className,
+  style,
+}: {
+  messageId: string;
+  reactions: ChatMessage['reactions'];
+  currentUserId?: string;
+  onReact: (messageId: string, emoji: string) => void;
+  className?: string;
+  style?: StyleProp<ViewStyle>;
+}) {
+  if (reactions.length === 0) return null;
+
+  return (
+    <View className={className} style={style}>
+      {reactions.map((reaction, index) => {
+        const isUserReaction =
+          !!currentUserId && reaction.userIds.includes(currentUserId);
+        return (
+          <Pressable
+            key={reaction.emoji}
+            onPress={() => onReact(messageId, reaction.emoji)}
+            className="items-center justify-center rounded-full"
+            style={{
+              backgroundColor: isUserReaction ? '#FFFFFF' : mflColors.card,
+              borderWidth: isUserReaction ? 0 : 2,
+              borderColor: mflColors.surface,
+              width: 32,
+              height: 32,
+              marginLeft: index > 0 ? -8 : 0,
+              zIndex: reactions.length - index,
+              shadowColor: '#000',
+              shadowOffset: { width: 0, height: 1 },
+              shadowOpacity: 0.1,
+              shadowRadius: 2,
+              elevation: 2,
+            }}
+          >
+            <AppText className="text-base">{reaction.emoji}</AppText>
+            {reaction.userIds.length > 1 ? (
+              <View
+                className="absolute -bottom-1 -right-1 items-center justify-center rounded-full"
+                style={{
+                  backgroundColor: isUserReaction ? mflColors.brand : mflColors.surface,
+                  borderWidth: 1.5,
+                  borderColor: mflColors.surface,
+                  minWidth: 16,
+                  height: 16,
+                  paddingHorizontal: 3,
+                }}
+              >
+                <AppText
+                  className="text-[9px] font-bold"
+                  style={{
+                    color: isUserReaction ? mflColors.white : mflColors.text,
+                  }}
+                >
+                  {reaction.userIds.length}
+                </AppText>
+              </View>
+            ) : null}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function MessageActions({
+  message,
+  currentUserId,
+  isOwn,
+  isCaptainBoost,
+  showEmojiPicker,
+  onReply,
+  onReact,
+  onToggleEmojiPicker,
+}: {
+  message: ChatMessage;
+  currentUserId?: string;
+  isOwn?: boolean;
+  isCaptainBoost?: boolean;
+  showEmojiPicker: boolean;
+  onReply: (message: ChatMessage) => void;
+  onReact: (messageId: string, emoji: string) => void;
+  onToggleEmojiPicker: () => void;
+}) {
+  const alignment = isCaptainBoost ? '' : isOwn ? 'justify-end' : 'justify-start';
+  return (
+    <>
+      <ChatMessageReactions
+        messageId={message.messageId}
+        reactions={message.reactions}
+        currentUserId={currentUserId}
+        onReact={onReact}
+        className={`${isCaptainBoost ? 'mt-1' : 'mb-2'} flex-row items-center ${alignment}`}
+        {...(!isCaptainBoost && { style: { marginLeft: isOwn ? 0 : 36 } })}
+      />
+      <View className={`${isCaptainBoost ? 'mt-1' : 'mb-2'} flex-row flex-wrap gap-1 ${alignment}`}>
+        <MessagingChip label="Reply" icon="corner-up-left" onPress={() => onReply(message)} />
+        <MessagingChip label="React" icon="plus" onPress={onToggleEmojiPicker} />
+      </View>
+      {showEmojiPicker ? (
+        <View className={`${isCaptainBoost ? 'mt-1' : 'mb-2'} flex-row flex-wrap gap-1 ${alignment}`}>
+          {QUICK_EMOJIS.map((emoji) => (
+            <MessagingChip
+              key={emoji}
+              label={emoji}
+              selected={message.reactions.some(
+                (r) => r.emoji === emoji && !!currentUserId && r.userIds.includes(currentUserId),
+              )}
+              onPress={() => {
+                onReact(message.messageId, emoji);
+                onToggleEmojiPicker();
+              }}
+            />
+          ))}
+        </View>
+      ) : null}
+    </>
   );
 }
 

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -206,7 +206,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
           onReply={setReplyTo}
           onReact={(messageId, emoji) => {
             reactionMutation.mutate(
-              { leagueId, messageId, emoji },
+              { leagueId, messageId, emoji, userId: user?.id },
               { onSuccess: () => messagesQuery.refetch() },
             );
           }}

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -205,16 +205,18 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
           isGrouped={isGrouped}
           onReply={setReplyTo}
           onReact={(messageId, emoji) => {
-            reactionMutation.mutate(
-              { leagueId, messageId, emoji, userId: user?.id },
-              { onSuccess: () => messagesQuery.refetch() },
-            );
+            reactionMutation.mutate({
+              leagueId,
+              messageId,
+              emoji,
+              userId: user?.id,
+            });
           }}
           onOpenDeepLink={openDeepLink}
         />
       );
     },
-    [leagueId, messages, messagesQuery, openDeepLink, reactionMutation, user?.id],
+    [leagueId, messages, openDeepLink, reactionMutation, user?.id],
   );
 
   const keyExtractor = useCallback((item: ChatMessage) => item.messageId, []);

--- a/src/features/messaging/hooks/use-toggle-chat-reaction.ts
+++ b/src/features/messaging/hooks/use-toggle-chat-reaction.ts
@@ -1,11 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toggleChatReaction } from '../services/messaging.service';
 import { messagingQueryKeys } from '../utils/messaging-query-keys';
+import type { ChatMessage } from '../types/messaging.model';
 
 interface ToggleChatReactionVars {
   leagueId: string;
   messageId: string;
   emoji: string;
+  userId?: string;
 }
 
 export function useToggleChatReaction() {
@@ -14,7 +16,81 @@ export function useToggleChatReaction() {
   return useMutation<{ success: boolean }, Error, ToggleChatReactionVars>({
     mutationFn: ({ leagueId, messageId, emoji }) =>
       toggleChatReaction(leagueId, messageId, emoji),
-    onSuccess: (_data, variables) => {
+    onMutate: async (variables) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: messagingQueryKeys.messagesRoot(variables.leagueId),
+      });
+
+      // Snapshot previous value
+      const previousMessages = queryClient.getQueriesData({
+        queryKey: messagingQueryKeys.messagesRoot(variables.leagueId),
+      });
+
+      // Optimistically update all message queries
+      queryClient.setQueriesData<ChatMessage[]>(
+        { queryKey: messagingQueryKeys.messagesRoot(variables.leagueId) },
+        (old) => {
+          if (!old) return old;
+          
+          return old.map((msg) => {
+            if (msg.messageId !== variables.messageId) return msg;
+            
+            const existingReaction = msg.reactions.find(r => r.emoji === variables.emoji);
+            
+            if (existingReaction && variables.userId) {
+              // Toggle off if user already reacted
+              if (existingReaction.userIds.includes(variables.userId)) {
+                const newUserIds = existingReaction.userIds.filter(id => id !== variables.userId);
+                return {
+                  ...msg,
+                  reactions: newUserIds.length > 0
+                    ? msg.reactions.map(r => 
+                        r.emoji === variables.emoji 
+                          ? { ...r, userIds: newUserIds }
+                          : r
+                      )
+                    : msg.reactions.filter(r => r.emoji !== variables.emoji)
+                };
+              } else {
+                // Add user to existing reaction
+                return {
+                  ...msg,
+                  reactions: msg.reactions.map(r =>
+                    r.emoji === variables.emoji
+                      ? { ...r, userIds: [...r.userIds, variables.userId] }
+                      : r
+                  )
+                };
+              }
+            } else if (variables.userId) {
+              // Add new reaction
+              return {
+                ...msg,
+                reactions: [
+                  ...msg.reactions,
+                  { emoji: variables.emoji, userIds: [variables.userId] }
+                ]
+              };
+            }
+            
+            return msg;
+          });
+        }
+      );
+
+      return { previousMessages };
+    },
+    onError: (_err, variables, context) => {
+      // Rollback on error
+      if (context?.previousMessages) {
+        context.previousMessages.forEach(([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        });
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      // Refetch to ensure consistency
       queryClient.invalidateQueries({
         queryKey: messagingQueryKeys.messagesRoot(variables.leagueId),
       });

--- a/src/features/messaging/hooks/use-toggle-chat-reaction.ts
+++ b/src/features/messaging/hooks/use-toggle-chat-reaction.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
 import { toggleChatReaction } from '../services/messaging.service';
 import { messagingQueryKeys } from '../utils/messaging-query-keys';
 import type { ChatMessage } from '../types/messaging.model';
@@ -13,7 +14,12 @@ interface ToggleChatReactionVars {
 export function useToggleChatReaction() {
   const queryClient = useQueryClient();
 
-  return useMutation<{ success: boolean }, Error, ToggleChatReactionVars>({
+  return useMutation<
+    { success: boolean },
+    Error,
+    ToggleChatReactionVars,
+    { previousMessages: [QueryKey, ChatMessage[] | undefined][] }
+  >({
     mutationFn: ({ leagueId, messageId, emoji }) =>
       toggleChatReaction(leagueId, messageId, emoji),
     onMutate: async (variables) => {
@@ -23,7 +29,7 @@ export function useToggleChatReaction() {
       });
 
       // Snapshot previous value
-      const previousMessages = queryClient.getQueriesData({
+      const previousMessages = queryClient.getQueriesData<ChatMessage[]>({
         queryKey: messagingQueryKeys.messagesRoot(variables.leagueId),
       });
 
@@ -32,16 +38,19 @@ export function useToggleChatReaction() {
         { queryKey: messagingQueryKeys.messagesRoot(variables.leagueId) },
         (old) => {
           if (!old) return old;
+
+          const userId = variables.userId;
+          if (!userId) return old;
           
           return old.map((msg) => {
             if (msg.messageId !== variables.messageId) return msg;
             
             const existingReaction = msg.reactions.find(r => r.emoji === variables.emoji);
             
-            if (existingReaction && variables.userId) {
+            if (existingReaction) {
               // Toggle off if user already reacted
-              if (existingReaction.userIds.includes(variables.userId)) {
-                const newUserIds = existingReaction.userIds.filter(id => id !== variables.userId);
+              if (existingReaction.userIds.includes(userId)) {
+                const newUserIds = existingReaction.userIds.filter(id => id !== userId);
                 return {
                   ...msg,
                   reactions: newUserIds.length > 0
@@ -58,33 +67,30 @@ export function useToggleChatReaction() {
                   ...msg,
                   reactions: msg.reactions.map(r =>
                     r.emoji === variables.emoji
-                      ? { ...r, userIds: [...r.userIds, variables.userId] }
+                      ? { ...r, userIds: [...r.userIds, userId] }
                       : r
                   )
                 };
               }
-            } else if (variables.userId) {
+            } else {
               // Add new reaction
               return {
                 ...msg,
                 reactions: [
                   ...msg.reactions,
-                  { emoji: variables.emoji, userIds: [variables.userId] }
+                  { emoji: variables.emoji, userIds: [userId] }
                 ]
               };
             }
-            
-            return msg;
           });
         }
       );
 
       return { previousMessages };
     },
-    onError: (_err, variables, context) => {
-      // Rollback on error
+    onError: (_err, _variables, context) => {
       if (context?.previousMessages) {
-        context.previousMessages.forEach(([queryKey, data]) => {
+        context.previousMessages.forEach(([queryKey, data]: [QueryKey, ChatMessage[] | undefined]) => {
           queryClient.setQueryData(queryKey, data);
         });
       }


### PR DESCRIPTION
## Summary

Reaction emoji UI improvements — WhatsApp/Instagram-style overlapping layout, selected reaction styling, hidden emoji picker.

## What was changed

1. **Overlapped reaction display** — reactions now overlap horizontally with `-8px` margin, proper z-index stacking, and subtle shadow for depth (WhatsApp/Instagram style)

2. **Pure white circle for selected reactions** — user's own reactions display in pure white (`#FFFFFF`) background with no border. Other users' reactions remain in card color with border

3. **Hidden emoji picker behind "+" button** — 6 quick reaction emojis hidden by default. Only "Reply" and "React" buttons show initially. Clicking "React" (+ icon) toggles the emoji picker. Selecting an emoji automatically closes the picker

4. **Improved reaction count badge** — small badge in bottom-right corner shows count when > 1, matches selection state (brand color for user's reaction)

## Screenshots

**before**
<img width="720" height="1600" alt="WhatsApp Image 2026-05-16 at 11 43 37" src="https://github.com/user-attachments/assets/d3b67e41-8a9d-43ac-a2ce-656cd4eeca19" />
**after**
<img width="720" height="1600" alt="WhatsApp Image 2026-05-16 at 11 43 49" src="https://github.com/user-attachments/assets/f8bfc611-51cf-47b8-b1b4-2b78c8e42894" />

## Tested

- Reaction display with multiple reactions — overlapping layout works
- White circle appears for user's own reactions, border removed
- "React" button toggles emoji picker, closes after selection
- Count badge displays correctly when > 1 reaction

## Impact

- Mobile app — chat message reactions

## Risk

- Low — UI-only changes, no backend modifications

## Files Modified

- `src/features/messaging/components/chat-message-bubble.tsx`
- `src/features/messaging/components/team-messaging-screen.tsx`
- `src/features/messaging/hooks/use-toggle-chat-reaction.ts`