### PR TITLE
feat: add Apple HealthKit support and Google Health display

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,6 +19,8 @@
         "NSCameraUsageDescription": "MFL needs camera access for activity proof photos",
         "NSMicrophoneUsageDescription": "MFL needs microphone access for team chat",
         "NSPhotoLibraryUsageDescription": "MFL needs photo library access for uploading activity proofs",
+        "NSHealthShareUsageDescription": "MFL reads your workouts, steps, distance, and energy from Apple Health to log fitness activities for your league.",
+        "NSHealthUpdateUsageDescription": "MFL does not write to Apple Health. This entry is required by iOS when requesting Health access.",
         "UIViewControllerBasedStatusBarAppearance": false,
         "UIBackgroundModes": [
           "remote-notification"
@@ -77,6 +79,14 @@
             "android.permission.health.READ_DISTANCE",
             "android.permission.health.READ_TOTAL_CALORIES_BURNED"
           ]
+        }
+      ],
+      [
+        "@kingstinct/react-native-healthkit",
+        {
+          "NSHealthShareUsageDescription": "MFL reads your workouts, steps, distance, and energy from Apple Health to log fitness activities for your league.",
+          "NSHealthUpdateUsageDescription": "MFL does not write to Apple Health. This entry is required by iOS when requesting Health access.",
+          "background": false
         }
       ]
     ],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@expo-google-fonts/space-grotesk": "^0.4.1",
     "@expo/metro-runtime": "~6.1.1",
     "@gorhom/bottom-sheet": "^5",
+    "@kingstinct/react-native-healthkit": "^14.0.1",
     "@react-native-firebase/analytics": "^24.0.0",
     "@react-native-firebase/app": "^24.0.0",
     "@react-native-firebase/crashlytics": "^24.0.0",

--- a/src/features/wearables/components/connected-apps-screen.tsx
+++ b/src/features/wearables/components/connected-apps-screen.tsx
@@ -6,11 +6,14 @@ import { AppText } from '../../../components/app-text';
 import { useLeagueContext } from '../../../contexts/league-context';
 import { mflColors } from '../../../constants/colors';
 import { useHealthConnect } from '../hooks/use-health-connect';
+import { useHealthKit } from '../hooks/use-healthkit';
 import {
   useWearableConnections,
   useRegisterHealthConnect,
+  useRegisterHealthKit,
   useDeleteWearableConnection,
   useSyncHealthConnect,
+  useSyncHealthKit,
 } from '../hooks/use-wearable-connections';
 import {
   usePendingConfirmations,
@@ -18,19 +21,27 @@ import {
   useRejectWorkout,
 } from '../hooks/use-pending-confirmations';
 import { HealthConnectCard } from './health-connect-card';
+import { HealthKitCard } from './healthkit-card';
 import { PendingConfirmationCard } from './pending-confirmation-card';
+
+const isIos = Platform.OS === 'ios';
+const isAndroid = Platform.OS === 'android';
 
 export function ConnectedAppsScreen() {
   const { activeLeague } = useLeagueContext();
   const leagueId = activeLeague?.leagueId ?? '';
 
   const hc = useHealthConnect();
+  const hk = useHealthKit();
+
   const connectionsQuery = useWearableConnections(leagueId);
   const pendingQuery = usePendingConfirmations(leagueId);
 
-  const registerMutation = useRegisterHealthConnect();
+  const registerHcMutation = useRegisterHealthConnect();
+  const registerHkMutation = useRegisterHealthKit();
   const deleteMutation = useDeleteWearableConnection();
-  const syncMutation = useSyncHealthConnect();
+  const syncHcMutation = useSyncHealthConnect();
+  const syncHkMutation = useSyncHealthKit();
   const confirmMutation = useConfirmWorkout();
   const rejectMutation = useRejectWorkout();
 
@@ -38,54 +49,78 @@ export function ConnectedAppsScreen() {
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
 
-  const hcConnection = connectionsQuery.data?.find((c) => c.provider === 'health_connect') ?? null;
+  const hcConnection =
+    connectionsQuery.data?.find((c) => c.provider === 'health_connect') ?? null;
+  const hkConnection =
+    connectionsQuery.data?.find((c) => c.provider === 'healthkit') ?? null;
+  // Google Health is connected via the web app (OAuth). Mobile only displays it.
+  const ghConnection =
+    connectionsQuery.data?.find(
+      (c) => c.provider === 'google_health' && c.status === 'active',
+    ) ?? null;
 
-  const handleConnect = useCallback(async () => {
+  // ---------- Health Connect (Android) handlers ----------
+  const handleConnectHc = useCallback(async () => {
     const granted = await hc.requestPermissions();
     if (!granted) {
-      Alert.alert('Permission Required', 'Health Connect permissions are needed to sync workouts.');
+      Alert.alert(
+        'Permission Required',
+        'Health Connect permissions are needed to sync workouts.',
+      );
       return;
     }
 
     try {
-      await registerMutation.mutateAsync({
+      await registerHcMutation.mutateAsync({
         leagueId,
-        deviceName: Platform.OS === 'android' ? `Android ${Platform.Version}` : undefined,
-        androidVersion: Platform.OS === 'android' ? String(Platform.Version) : undefined,
+        deviceName: `Android ${Platform.Version}`,
+        androidVersion: String(Platform.Version),
       });
     } catch {
       Alert.alert('Error', 'Failed to register Health Connect with server.');
     }
-  }, [hc, registerMutation, leagueId]);
+  }, [hc, registerHcMutation, leagueId]);
 
-  const handleSync = useCallback(async () => {
+  const handleSyncHc = useCallback(async () => {
     try {
       const activities = await hc.readRecentWorkouts(7);
       if (activities.length === 0) {
-        Alert.alert('No Workouts', 'No new workouts found in Health Connect for the last 7 days.');
+        Alert.alert(
+          'No Workouts',
+          'No new workouts found in Health Connect for the last 7 days.',
+        );
         setLastSyncCount(0);
         return;
       }
 
-      const result = await syncMutation.mutateAsync({ leagueId, activities });
+      const result = await syncHcMutation.mutateAsync({
+        leagueId,
+        activities,
+        connectionId: hcConnection?.connectionId ?? null,
+      });
       setLastSyncCount(result.imported);
 
       if (result.imported > 0) {
         Alert.alert(
           'Sync Complete',
           `${result.imported} workout${result.imported !== 1 ? 's' : ''} imported.${
-            result.duplicates > 0 ? ` ${result.duplicates} duplicate(s) skipped.` : ''
+            result.duplicates > 0
+              ? ` ${result.duplicates} duplicate(s) skipped.`
+              : ''
           }`,
         );
       } else {
-        Alert.alert('Sync Complete', 'No new workouts to import. All are already synced.');
+        Alert.alert(
+          'Sync Complete',
+          'No new workouts to import. All are already synced.',
+        );
       }
     } catch {
       Alert.alert('Sync Failed', 'Failed to sync workouts. Please try again.');
     }
-  }, [hc, syncMutation, leagueId]);
+  }, [hc, syncHcMutation, leagueId, hcConnection]);
 
-  const handleDisconnect = useCallback(async () => {
+  const handleDisconnectHc = useCallback(async () => {
     await hc.disconnect();
     if (hcConnection) {
       try {
@@ -99,12 +134,94 @@ export function ConnectedAppsScreen() {
     }
   }, [hc, hcConnection, deleteMutation, leagueId]);
 
+  // ---------- HealthKit (iOS) handlers ----------
+  const handleConnectHk = useCallback(async () => {
+    const granted = await hk.requestPermissions();
+    if (!granted) {
+      Alert.alert(
+        'Permission Required',
+        'Open the iOS Settings app and enable Apple Health access for MFL under Privacy & Security > Health.',
+      );
+      return;
+    }
+
+    try {
+      await registerHkMutation.mutateAsync({
+        leagueId,
+        deviceName: `iPhone (iOS ${Platform.Version})`,
+        iosVersion: String(Platform.Version),
+      });
+    } catch {
+      Alert.alert('Error', 'Failed to register Apple Health with server.');
+    }
+  }, [hk, registerHkMutation, leagueId]);
+
+  const handleSyncHk = useCallback(async () => {
+    try {
+      const activities = await hk.readRecentWorkouts(7);
+      if (activities.length === 0) {
+        Alert.alert(
+          'No Workouts',
+          'No new workouts found in Apple Health for the last 7 days.',
+        );
+        setLastSyncCount(0);
+        return;
+      }
+
+      const result = await syncHkMutation.mutateAsync({
+        leagueId,
+        activities,
+        connectionId: hkConnection?.connectionId ?? null,
+      });
+      setLastSyncCount(result.imported);
+
+      if (result.imported > 0) {
+        Alert.alert(
+          'Sync Complete',
+          `${result.imported} workout${result.imported !== 1 ? 's' : ''} imported.${
+            result.duplicates > 0
+              ? ` ${result.duplicates} duplicate(s) skipped.`
+              : ''
+          }`,
+        );
+      } else {
+        Alert.alert(
+          'Sync Complete',
+          'No new workouts to import. All are already synced.',
+        );
+      }
+    } catch {
+      Alert.alert('Sync Failed', 'Failed to sync workouts. Please try again.');
+    }
+  }, [hk, syncHkMutation, leagueId, hkConnection]);
+
+  const handleDisconnectHk = useCallback(async () => {
+    await hk.disconnect();
+    if (hkConnection) {
+      try {
+        await deleteMutation.mutateAsync({
+          leagueId,
+          connectionId: hkConnection.connectionId,
+        });
+      } catch {
+        // Connection removed locally even if server fails
+      }
+    }
+  }, [hk, hkConnection, deleteMutation, leagueId]);
+
+  // ---------- Pending confirmations ----------
   const handleConfirm = useCallback(
     async (workoutId: string) => {
       setConfirmingId(workoutId);
       try {
-        const result = await confirmMutation.mutateAsync({ leagueId, workoutId });
-        Alert.alert('Confirmed', `${result.pointsAwarded} point${result.pointsAwarded !== 1 ? 's' : ''} awarded!`);
+        const result = await confirmMutation.mutateAsync({
+          leagueId,
+          workoutId,
+        });
+        Alert.alert(
+          'Confirmed',
+          `${result.pointsAwarded} point${result.pointsAwarded !== 1 ? 's' : ''} awarded!`,
+        );
       } catch {
         Alert.alert('Error', 'Failed to confirm workout.');
       } finally {
@@ -130,8 +247,9 @@ export function ConnectedAppsScreen() {
 
   const handleRefresh = useCallback(async () => {
     await Promise.all([connectionsQuery.refetch(), pendingQuery.refetch()]);
-    await hc.recheckStatus();
-  }, [connectionsQuery, pendingQuery, hc]);
+    if (isAndroid) await hc.recheckStatus();
+    if (isIos) await hk.recheckStatus();
+  }, [connectionsQuery, pendingQuery, hc, hk]);
 
   if (!activeLeague) {
     return (
@@ -164,6 +282,9 @@ export function ConnectedAppsScreen() {
 
   const pendingWorkouts = pendingQuery.data ?? [];
 
+  const providerStatus = isIos ? hk.status : hc.status;
+  const isConnectedToProvider = providerStatus === 'connected';
+
   return (
     <ScreenScrollView onRefresh={handleRefresh}>
       <View className="gap-6 py-4">
@@ -171,16 +292,58 @@ export function ConnectedAppsScreen() {
           Connected Apps & Wearables
         </AppText>
 
-        <HealthConnectCard
-          status={hc.status}
-          connection={hcConnection}
-          isInitializing={hc.isInitializing}
-          isSyncing={hc.isSyncing || syncMutation.isPending}
-          lastSyncCount={lastSyncCount}
-          onConnect={handleConnect}
-          onSync={handleSync}
-          onDisconnect={handleDisconnect}
-        />
+        {isIos && (
+          <HealthKitCard
+            status={hk.status}
+            connection={hkConnection}
+            isInitializing={hk.isInitializing}
+            isSyncing={hk.isSyncing || syncHkMutation.isPending}
+            lastSyncCount={lastSyncCount}
+            onConnect={handleConnectHk}
+            onSync={handleSyncHk}
+            onDisconnect={handleDisconnectHk}
+          />
+        )}
+
+        {isAndroid && (
+          <HealthConnectCard
+            status={hc.status}
+            connection={hcConnection}
+            isInitializing={hc.isInitializing}
+            isSyncing={hc.isSyncing || syncHcMutation.isPending}
+            lastSyncCount={lastSyncCount}
+            onConnect={handleConnectHc}
+            onSync={handleSyncHc}
+            onDisconnect={handleDisconnectHc}
+          />
+        )}
+
+        {ghConnection && (
+          <View className="rounded-2xl bg-content1 p-4">
+            <View className="flex-row items-center gap-3">
+              <View
+                className="w-10 h-10 rounded-xl items-center justify-center"
+                style={{ backgroundColor: `${mflColors.brand}15` }}
+              >
+                <AppText
+                  className="text-base"
+                  style={{ color: mflColors.brand }}
+                >
+                  ✓
+                </AppText>
+              </View>
+              <View className="flex-1">
+                <AppText className="text-base font-semibold text-foreground">
+                  Google Health
+                </AppText>
+                <AppText className="text-xs text-muted mt-0.5">
+                  Connected via the MFL web app. Manage and sync it from
+                  Connected Apps on the website.
+                </AppText>
+              </View>
+            </View>
+          </View>
+        )}
 
         {pendingWorkouts.length > 0 && (
           <View className="gap-3">
@@ -192,7 +355,10 @@ export function ConnectedAppsScreen() {
                 className="rounded-full px-2 py-0.5"
                 style={{ backgroundColor: `${mflColors.amber}20` }}
               >
-                <AppText className="text-xs font-semibold" style={{ color: mflColors.amber }}>
+                <AppText
+                  className="text-xs font-semibold"
+                  style={{ color: mflColors.amber }}
+                >
                   {pendingWorkouts.length}
                 </AppText>
               </View>
@@ -211,10 +377,12 @@ export function ConnectedAppsScreen() {
           </View>
         )}
 
-        {pendingWorkouts.length === 0 && hc.status === 'connected' && (
+        {pendingWorkouts.length === 0 && isConnectedToProvider && (
           <View className="rounded-2xl bg-content1 p-4 items-center">
             <AppText className="text-sm text-muted text-center">
-              No pending workouts. Sync from Health Connect to import new activities.
+              No pending workouts. Sync from{' '}
+              {isIos ? 'Apple Health' : 'Health Connect'} to import new
+              activities.
             </AppText>
           </View>
         )}

--- a/src/features/wearables/components/healthkit-card.tsx
+++ b/src/features/wearables/components/healthkit-card.tsx
@@ -2,11 +2,13 @@ import Feather from '@expo/vector-icons/Feather';
 import { Alert, Pressable, View } from 'react-native';
 import { AppText } from '../../../components/app-text';
 import { mflColors } from '../../../constants/colors';
-import type { HealthConnectStatus } from '../types/wearable.model';
-import type { WearableConnection } from '../types/wearable.model';
+import type {
+  HealthKitStatus,
+  WearableConnection,
+} from '../types/wearable.model';
 
-interface HealthConnectCardProps {
-  status: HealthConnectStatus;
+interface HealthKitCardProps {
+  status: HealthKitStatus;
   connection: WearableConnection | null;
   isInitializing: boolean;
   isSyncing: boolean;
@@ -17,17 +19,27 @@ interface HealthConnectCardProps {
 }
 
 const STATUS_CONFIG: Record<
-  HealthConnectStatus,
+  HealthKitStatus,
   { label: string; color: string; icon: keyof typeof Feather.glyphMap }
 > = {
-  unsupported: { label: 'Not Available', color: mflColors.textMuted, icon: 'x-circle' },
-  not_installed: { label: 'Not Installed', color: mflColors.amber, icon: 'download' },
-  not_connected: { label: 'Not Connected', color: mflColors.textMuted, icon: 'link' },
-  permission_needed: { label: 'Permission Needed', color: mflColors.amber, icon: 'shield' },
-  connected: { label: 'Connected', color: mflColors.brand, icon: 'check-circle' },
+  unsupported: {
+    label: 'Not Available',
+    color: mflColors.textMuted,
+    icon: 'x-circle',
+  },
+  not_connected: {
+    label: 'Not Connected',
+    color: mflColors.textMuted,
+    icon: 'link',
+  },
+  connected: {
+    label: 'Connected',
+    color: mflColors.brand,
+    icon: 'check-circle',
+  },
 };
 
-export function HealthConnectCard({
+export function HealthKitCard({
   status,
   connection,
   isInitializing,
@@ -36,13 +48,13 @@ export function HealthConnectCard({
   onConnect,
   onSync,
   onDisconnect,
-}: HealthConnectCardProps) {
+}: HealthKitCardProps) {
   const config = STATUS_CONFIG[status];
 
   const handleDisconnect = () => {
     Alert.alert(
-      'Disconnect Health Connect',
-      'This will revoke all Health Connect permissions and remove the connection.',
+      'Disconnect Apple Health',
+      'This will remove the MFL connection. You can manage HealthKit data access for MFL anytime from iOS Settings > Privacy > Health.',
       [
         { text: 'Cancel', style: 'cancel' },
         { text: 'Disconnect', style: 'destructive', onPress: onDisconnect },
@@ -60,7 +72,9 @@ export function HealthConnectCard({
           <Feather name="heart" size={20} color={config.color} />
         </View>
         <View className="flex-1">
-          <AppText className="text-base font-semibold text-foreground">Health Connect</AppText>
+          <AppText className="text-base font-semibold text-foreground">
+            Apple Health
+          </AppText>
           <View className="flex-row items-center gap-1.5 mt-0.5">
             <Feather name={config.icon} size={12} color={config.color} />
             <AppText className="text-xs" style={{ color: config.color }}>
@@ -72,14 +86,15 @@ export function HealthConnectCard({
 
       {status === 'unsupported' && (
         <AppText className="text-xs text-muted mb-3">
-          Health Connect is not supported on this device. Android 13+ with Health Connect app
-          or Android 14+ is required.
+          Apple Health is only available on iPhone. iPad and other devices are
+          not supported.
         </AppText>
       )}
 
-      {status === 'not_installed' && (
-        <AppText className="text-xs text-muted mb-3">
-          Health Connect needs to be updated. Please update the Health Connect app from the Play Store.
+      {status === 'connected' && (
+        <AppText className="text-[11px] text-muted mb-2">
+          HealthKit data stays on this device. You can manage MFL&apos;s data
+          access from iOS Settings &gt; Privacy &amp; Security &gt; Health.
         </AppText>
       )}
 
@@ -90,15 +105,19 @@ export function HealthConnectCard({
       )}
 
       {lastSyncCount !== null && lastSyncCount > 0 && (
-        <AppText className="text-xs mb-3" style={{ color: mflColors.brand }}>
-          {lastSyncCount} workout{lastSyncCount !== 1 ? 's' : ''} imported from last sync
+        <AppText
+          className="text-xs mb-3"
+          style={{ color: mflColors.brand }}
+        >
+          {lastSyncCount} workout{lastSyncCount !== 1 ? 's' : ''} imported from
+          last sync
         </AppText>
       )}
 
       <View className="flex-row gap-2 mt-1">
-        {(status === 'not_connected' || status === 'permission_needed') && (
+        {status === 'not_connected' && (
           <ActionButton
-            label={isInitializing ? 'Connecting...' : 'Connect Health Connect'}
+            label={isInitializing ? 'Connecting...' : 'Connect Apple Health'}
             icon="link"
             color={mflColors.brand}
             disabled={isInitializing}

--- a/src/features/wearables/hooks/use-healthkit.ts
+++ b/src/features/wearables/hooks/use-healthkit.ts
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+import type { HealthKitStatus } from '../types/wearable.model';
+import type { NormalizedActivityDTO } from '../types/wearable.dto';
+import {
+  normalizeHealthKitWorkout,
+  type HealthKitWorkoutInput,
+} from '../utils/normalize-healthkit';
+
+type HKModule = typeof import('@kingstinct/react-native-healthkit');
+
+let _hk: HKModule | null = null;
+
+function getHK(): HKModule | null {
+  if (Platform.OS !== 'ios') return null;
+  if (!_hk) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      _hk = require('@kingstinct/react-native-healthkit') as HKModule;
+    } catch {
+      _hk = null;
+    }
+  }
+  return _hk;
+}
+
+// Mirrors the @kingstinct/react-native-healthkit identifier strings.
+// HealthKit read permissions are silent — the system tells the app
+// only whether the user has been asked, not whether they granted.
+const READ_PERMISSIONS = [
+  'HKWorkoutTypeIdentifier',
+  'HKQuantityTypeIdentifierStepCount',
+  'HKQuantityTypeIdentifierDistanceWalkingRunning',
+  'HKQuantityTypeIdentifierDistanceCycling',
+  'HKQuantityTypeIdentifierActiveEnergyBurned',
+  'HKQuantityTypeIdentifierBasalEnergyBurned',
+] as const;
+
+// AuthorizationRequestStatus enum values from @kingstinct/react-native-healthkit.
+const AUTH_STATUS_UNNECESSARY = 2;
+
+export function useHealthKit() {
+  const [status, setStatus] = useState<HealthKitStatus>(
+    Platform.OS !== 'ios' ? 'unsupported' : 'not_connected',
+  );
+  const [isInitializing, setIsInitializing] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const checkAvailability = useCallback(async () => {
+    const hk = getHK();
+    if (!hk) {
+      setStatus('unsupported');
+      return;
+    }
+
+    try {
+      const available = hk.isHealthDataAvailable();
+      if (!available) {
+        setStatus('unsupported');
+        return;
+      }
+
+      const requestStatus = await hk.getRequestStatusForAuthorization({
+        toRead: [...READ_PERMISSIONS],
+      });
+
+      setStatus(
+        requestStatus === AUTH_STATUS_UNNECESSARY ? 'connected' : 'not_connected',
+      );
+    } catch {
+      setStatus('not_connected');
+    }
+  }, []);
+
+  useEffect(() => {
+    void checkAvailability();
+  }, [checkAvailability]);
+
+  const requestPermissions = useCallback(async (): Promise<boolean> => {
+    const hk = getHK();
+    if (!hk) return false;
+
+    setIsInitializing(true);
+    try {
+      // requestAuthorization resolves to true once the system finishes presenting
+      // the auth sheet — it does not tell us whether read was granted (HealthKit
+      // privacy). We then check getRequestStatusForAuthorization to confirm the
+      // user has been prompted at least once.
+      await hk.requestAuthorization({ toRead: [...READ_PERMISSIONS] });
+
+      const requestStatus = await hk.getRequestStatusForAuthorization({
+        toRead: [...READ_PERMISSIONS],
+      });
+
+      const isConnected = requestStatus === AUTH_STATUS_UNNECESSARY;
+      setStatus(isConnected ? 'connected' : 'not_connected');
+      return isConnected;
+    } catch {
+      setStatus('not_connected');
+      return false;
+    } finally {
+      setIsInitializing(false);
+    }
+  }, []);
+
+  const readRecentWorkouts = useCallback(
+    async (daysBack = 7): Promise<NormalizedActivityDTO[]> => {
+      const hk = getHK();
+      if (!hk) return [];
+
+      setIsSyncing(true);
+      try {
+        const endDate = new Date();
+        const startDate = new Date(
+          Date.now() - daysBack * 24 * 60 * 60 * 1000,
+        );
+
+        const workouts = await hk.queryWorkoutSamples({
+          filter: { date: { startDate, endDate } },
+          limit: 0,
+          ascending: false,
+        });
+
+        const results: NormalizedActivityDTO[] = [];
+        for (const workout of workouts) {
+          const aggregated = await aggregateForWorkout(hk, workout);
+          results.push(
+            normalizeHealthKitWorkout(
+              workout as unknown as HealthKitWorkoutInput,
+              aggregated,
+            ),
+          );
+        }
+
+        return results;
+      } finally {
+        setIsSyncing(false);
+      }
+    },
+    [],
+  );
+
+  // HealthKit has no programmatic "revoke" API — the user manages it in Settings.
+  // We treat disconnect as a local status reset; backend connection deletion is
+  // handled by the caller via the existing wearable-connection delete endpoint.
+  const disconnect = useCallback(async () => {
+    setStatus('not_connected');
+  }, []);
+
+  return {
+    status,
+    isInitializing,
+    isSyncing,
+    requestPermissions,
+    readRecentWorkouts,
+    disconnect,
+    recheckStatus: checkAvailability,
+  };
+}
+
+interface QuantitySumResponse {
+  sumQuantity?: { quantity: number; unit: string };
+}
+
+async function safeSum<T extends string>(
+  hk: HKModule,
+  identifier: T,
+  workout: unknown,
+): Promise<number | null> {
+  try {
+    const result = (await hk.queryStatisticsForQuantity(
+      identifier as never,
+      ['cumulativeSum'] as const,
+      // Filter by workout so we only sum samples attributed to this workout.
+      { filter: { workout: workout as never } } as never,
+    )) as QuantitySumResponse;
+
+    return result?.sumQuantity?.quantity ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function aggregateForWorkout(
+  hk: HKModule,
+  workout: unknown,
+): Promise<{
+  steps: number | null;
+  distanceMeters: number | null;
+  calories: number | null;
+}> {
+  const [steps, walkingRunning, cycling, active, basal] = await Promise.all([
+    safeSum(hk, 'HKQuantityTypeIdentifierStepCount', workout),
+    safeSum(hk, 'HKQuantityTypeIdentifierDistanceWalkingRunning', workout),
+    safeSum(hk, 'HKQuantityTypeIdentifierDistanceCycling', workout),
+    safeSum(hk, 'HKQuantityTypeIdentifierActiveEnergyBurned', workout),
+    safeSum(hk, 'HKQuantityTypeIdentifierBasalEnergyBurned', workout),
+  ]);
+
+  const distanceMeters =
+    walkingRunning != null || cycling != null
+      ? (walkingRunning ?? 0) + (cycling ?? 0)
+      : null;
+
+  const calories =
+    active != null || basal != null ? (active ?? 0) + (basal ?? 0) : null;
+
+  return { steps, distanceMeters, calories };
+}

--- a/src/features/wearables/hooks/use-wearable-connections.ts
+++ b/src/features/wearables/hooks/use-wearable-connections.ts
@@ -3,8 +3,10 @@ import { queryKeys } from '../../../core/config';
 import {
   fetchWearableConnections,
   registerHealthConnect,
+  registerHealthKit,
   deleteWearableConnection,
   syncHealthConnect,
+  syncHealthKit,
 } from '../services/wearable.service';
 import { toWearableConnection } from '../mappers/wearable.mapper';
 import type { WearableConnection, SyncResult } from '../types/wearable.model';
@@ -42,6 +44,26 @@ export function useRegisterHealthConnect() {
   });
 }
 
+export function useRegisterHealthKit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { connectionId: string },
+    Error,
+    { leagueId: string; deviceName?: string; iosVersion?: string }
+  >({
+    mutationFn: async ({ leagueId, ...data }) => {
+      const res = await registerHealthKit(leagueId, data);
+      return { connectionId: res.data.connection_id };
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.wearableConnections(variables.leagueId),
+      });
+    },
+  });
+}
+
 export function useDeleteWearableConnection() {
   const queryClient = useQueryClient();
 
@@ -67,10 +89,41 @@ export function useSyncHealthConnect() {
   return useMutation<
     SyncResult,
     Error,
-    { leagueId: string; activities: NormalizedActivityDTO[] }
+    {
+      leagueId: string;
+      activities: NormalizedActivityDTO[];
+      connectionId?: string | null;
+    }
   >({
-    mutationFn: async ({ leagueId, activities }) => {
-      const res = await syncHealthConnect(leagueId, activities);
+    mutationFn: async ({ leagueId, activities, connectionId }) => {
+      const res = await syncHealthConnect(leagueId, activities, connectionId);
+      return { imported: res.data.imported, duplicates: res.data.duplicates };
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.wearableConnections(variables.leagueId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.pendingConfirmations(variables.leagueId),
+      });
+    },
+  });
+}
+
+export function useSyncHealthKit() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    SyncResult,
+    Error,
+    {
+      leagueId: string;
+      activities: NormalizedActivityDTO[];
+      connectionId?: string | null;
+    }
+  >({
+    mutationFn: async ({ leagueId, activities, connectionId }) => {
+      const res = await syncHealthKit(leagueId, activities, connectionId);
       return { imported: res.data.imported, duplicates: res.data.duplicates };
     },
     onSuccess: (_data, variables) => {

--- a/src/features/wearables/index.ts
+++ b/src/features/wearables/index.ts
@@ -1,9 +1,12 @@
 export { useHealthConnect } from './hooks/use-health-connect';
+export { useHealthKit } from './hooks/use-healthkit';
 export {
   useWearableConnections,
   useRegisterHealthConnect,
+  useRegisterHealthKit,
   useDeleteWearableConnection,
   useSyncHealthConnect,
+  useSyncHealthKit,
 } from './hooks/use-wearable-connections';
 export {
   usePendingConfirmations,
@@ -12,12 +15,15 @@ export {
 } from './hooks/use-pending-confirmations';
 export { ConnectedAppsScreen } from './components/connected-apps-screen';
 export { HealthConnectCard } from './components/health-connect-card';
+export { HealthKitCard } from './components/healthkit-card';
 export { PendingConfirmationCard } from './components/pending-confirmation-card';
 export { SyncedWorkoutRow } from './components/synced-workout-row';
 export type {
   WearableConnection,
+  WearableProvider,
   PendingWorkout,
   SyncResult,
   ConfirmResult,
   HealthConnectStatus,
+  HealthKitStatus,
 } from './types/wearable.model';

--- a/src/features/wearables/services/wearable.service.ts
+++ b/src/features/wearables/services/wearable.service.ts
@@ -1,8 +1,8 @@
 import { api } from '../../../core/api';
 import type {
   WearableConnectionsResponseDTO,
-  RegisterHealthConnectResponseDTO,
-  SyncHealthConnectResponseDTO,
+  RegisterWearableResponseDTO,
+  SyncWearableResponseDTO,
   PendingConfirmationsResponseDTO,
   ConfirmWorkoutResponseDTO,
   RejectWorkoutResponseDTO,
@@ -20,10 +20,21 @@ export async function fetchWearableConnections(
 
 export async function registerHealthConnect(
   leagueId: string,
-  data: { deviceName?: string; androidVersion?: string },
-): Promise<RegisterHealthConnectResponseDTO> {
-  const res = await api.post<RegisterHealthConnectResponseDTO>(
+  data: { deviceName?: string; androidVersion?: string; device_name?: string },
+): Promise<RegisterWearableResponseDTO> {
+  const res = await api.post<RegisterWearableResponseDTO>(
     `/api/leagues/${leagueId}/wearables/health-connect/register`,
+    data,
+  );
+  return res.data;
+}
+
+export async function registerHealthKit(
+  leagueId: string,
+  data: { deviceName?: string; iosVersion?: string; device_name?: string },
+): Promise<RegisterWearableResponseDTO> {
+  const res = await api.post<RegisterWearableResponseDTO>(
+    `/api/leagues/${leagueId}/wearables/healthkit/register`,
     data,
   );
   return res.data;
@@ -42,10 +53,27 @@ export async function deleteWearableConnection(
 export async function syncHealthConnect(
   leagueId: string,
   activities: NormalizedActivityDTO[],
-): Promise<SyncHealthConnectResponseDTO> {
-  const res = await api.post<SyncHealthConnectResponseDTO>(
+  connectionId?: string | null,
+): Promise<SyncWearableResponseDTO> {
+  const res = await api.post<SyncWearableResponseDTO>(
     `/api/leagues/${leagueId}/wearables/health-connect/sync`,
-    { activities },
+    connectionId
+      ? { activities, connection_id: connectionId }
+      : { activities },
+  );
+  return res.data;
+}
+
+export async function syncHealthKit(
+  leagueId: string,
+  activities: NormalizedActivityDTO[],
+  connectionId?: string | null,
+): Promise<SyncWearableResponseDTO> {
+  const res = await api.post<SyncWearableResponseDTO>(
+    `/api/leagues/${leagueId}/wearables/healthkit/sync`,
+    connectionId
+      ? { activities, connection_id: connectionId }
+      : { activities },
   );
   return res.data;
 }

--- a/src/features/wearables/types/index.ts
+++ b/src/features/wearables/types/index.ts
@@ -3,17 +3,22 @@ export type {
   WearableConnectionsResponseDTO,
   RegisterHealthConnectResponseDTO,
   SyncHealthConnectResponseDTO,
+  RegisterWearableResponseDTO,
+  SyncWearableResponseDTO,
   PendingWorkoutDTO,
   PendingConfirmationsResponseDTO,
   ConfirmWorkoutResponseDTO,
   RejectWorkoutResponseDTO,
   NormalizedActivityDTO,
+  WearableProvider as WearableProviderDTO,
 } from './wearable.dto';
 
 export type {
   WearableConnection,
+  WearableProvider,
   PendingWorkout,
   SyncResult,
   ConfirmResult,
   HealthConnectStatus,
+  HealthKitStatus,
 } from './wearable.model';

--- a/src/features/wearables/types/wearable.dto.ts
+++ b/src/features/wearables/types/wearable.dto.ts
@@ -1,6 +1,12 @@
+export type WearableProvider =
+  | 'health_connect'
+  | 'healthkit'
+  | 'strava'
+  | 'google_health';
+
 export interface WearableConnectionDTO {
   connection_id: string;
-  provider: 'health_connect' | 'strava' | 'google_health';
+  provider: WearableProvider;
   status: 'active' | 'disconnected' | 'expired';
   device_name: string | null;
   last_synced_at: string | null;
@@ -14,20 +20,24 @@ export interface WearableConnectionsResponseDTO {
   };
 }
 
-export interface RegisterHealthConnectResponseDTO {
+export interface RegisterWearableResponseDTO {
   success: boolean;
   data: {
     connection_id: string;
   };
 }
 
-export interface SyncHealthConnectResponseDTO {
+export interface SyncWearableResponseDTO {
   success: boolean;
   data: {
     imported: number;
     duplicates: number;
   };
 }
+
+// Backwards-compatible aliases for existing imports.
+export type RegisterHealthConnectResponseDTO = RegisterWearableResponseDTO;
+export type SyncHealthConnectResponseDTO = SyncWearableResponseDTO;
 
 export interface PendingWorkoutDTO {
   workout_id: string;
@@ -64,7 +74,7 @@ export interface RejectWorkoutResponseDTO {
 }
 
 export interface NormalizedActivityDTO {
-  provider: 'health_connect';
+  provider: 'health_connect' | 'healthkit';
   provider_activity_id: string;
   activity_type: string;
   started_at: string;

--- a/src/features/wearables/types/wearable.model.ts
+++ b/src/features/wearables/types/wearable.model.ts
@@ -1,6 +1,12 @@
+export type WearableProvider =
+  | 'health_connect'
+  | 'healthkit'
+  | 'strava'
+  | 'google_health';
+
 export interface WearableConnection {
   connectionId: string;
-  provider: 'health_connect' | 'strava' | 'google_health';
+  provider: WearableProvider;
   status: 'active' | 'disconnected' | 'expired';
   deviceName: string | null;
   lastSyncedAt: string | null;
@@ -37,4 +43,9 @@ export type HealthConnectStatus =
   | 'not_installed'
   | 'not_connected'
   | 'permission_needed'
+  | 'connected';
+
+export type HealthKitStatus =
+  | 'unsupported'
+  | 'not_connected'
   | 'connected';

--- a/src/features/wearables/utils/normalize-healthkit.ts
+++ b/src/features/wearables/utils/normalize-healthkit.ts
@@ -1,0 +1,172 @@
+import { Platform } from 'react-native';
+import type { NormalizedActivityDTO } from '../types/wearable.dto';
+
+// Mirrors @kingstinct/react-native-healthkit's WorkoutActivityType enum.
+// Source of truth: HKWorkoutActivityType in the package's generated types.
+// We label-map to readable activity names that backend mapActivityType already understands
+// (running, walking, cycling, swimming, yoga, etc.).
+const ACTIVITY_TYPE_NAMES: Record<number, string> = {
+  1: 'American Football',
+  2: 'Archery',
+  3: 'Australian Football',
+  4: 'Badminton',
+  5: 'Baseball',
+  6: 'Basketball',
+  7: 'Bowling',
+  8: 'Boxing',
+  9: 'Climbing',
+  10: 'Cricket',
+  11: 'Cross Training',
+  12: 'Curling',
+  13: 'Cycling',
+  14: 'Dance',
+  15: 'Dance Inspired Training',
+  16: 'Elliptical',
+  17: 'Equestrian Sports',
+  18: 'Fencing',
+  19: 'Fishing',
+  20: 'Functional Strength Training',
+  21: 'Golf',
+  22: 'Gymnastics',
+  23: 'Handball',
+  24: 'Hiking',
+  25: 'Hockey',
+  26: 'Hunting',
+  27: 'Lacrosse',
+  28: 'Martial Arts',
+  29: 'Mind And Body',
+  30: 'Mixed Metabolic Cardio Training',
+  31: 'Paddle Sports',
+  32: 'Play',
+  33: 'Preparation And Recovery',
+  34: 'Racquetball',
+  35: 'Rowing',
+  36: 'Rugby',
+  37: 'Running',
+  38: 'Sailing',
+  39: 'Skating Sports',
+  40: 'Snow Sports',
+  41: 'Soccer',
+  42: 'Softball',
+  43: 'Squash',
+  44: 'Stair Climbing',
+  45: 'Surfing Sports',
+  46: 'Swimming',
+  47: 'Table Tennis',
+  48: 'Tennis',
+  49: 'Track And Field',
+  50: 'Traditional Strength Training',
+  51: 'Volleyball',
+  52: 'Walking',
+  53: 'Water Fitness',
+  54: 'Water Polo',
+  55: 'Water Sports',
+  56: 'Wrestling',
+  57: 'Yoga',
+  58: 'Barre',
+  59: 'Core Training',
+  60: 'Cross Country Skiing',
+  61: 'Downhill Skiing',
+  62: 'Flexibility',
+  63: 'HIIT',
+  64: 'Jump Rope',
+  65: 'Kickboxing',
+  66: 'Pilates',
+  67: 'Snowboarding',
+  68: 'Stairs',
+  69: 'Step Training',
+  70: 'Wheelchair Walk Pace',
+  71: 'Wheelchair Run Pace',
+  72: 'Tai Chi',
+  73: 'Mixed Cardio',
+  74: 'Hand Cycling',
+  75: 'Disc Sports',
+  76: 'Fitness Gaming',
+  77: 'Cardio Dance',
+  78: 'Social Dance',
+  79: 'Pickleball',
+  80: 'Cooldown',
+  82: 'Swim Bike Run',
+  83: 'Transition',
+  84: 'Underwater Diving',
+  3000: 'Other Workout',
+};
+
+function getActivityTypeName(type: number | undefined | null): string {
+  if (type == null) return 'Other Workout';
+  return ACTIVITY_TYPE_NAMES[type] ?? 'Other Workout';
+}
+
+function computeDurationSeconds(startDate: Date, endDate: Date): number {
+  const start = startDate.getTime();
+  const end = endDate.getTime();
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0;
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+export interface HealthKitWorkoutInput {
+  uuid: string;
+  workoutActivityType: number;
+  startDate: Date;
+  endDate: Date;
+  duration?: { quantity: number; unit: string };
+  totalEnergyBurned?: { quantity: number; unit: string };
+  totalDistance?: { quantity: number; unit: string };
+  sourceRevision?: {
+    source: { name: string; bundleIdentifier: string };
+  };
+  device?: {
+    name?: string;
+    model?: string;
+    manufacturer?: string;
+  };
+}
+
+export interface HealthKitAggregatedData {
+  steps: number | null;
+  distanceMeters: number | null;
+  calories: number | null;
+}
+
+/**
+ * Convert a HealthKit workout (HKWorkout) into the shared NormalizedActivityDTO shape.
+ * Distance and calories are taken from the workout totals first; aggregated quantity-sample
+ * fallbacks (e.g. when totals are missing) come from the hook layer.
+ */
+export function normalizeHealthKitWorkout(
+  workout: HealthKitWorkoutInput,
+  aggregated: HealthKitAggregatedData,
+): NormalizedActivityDTO {
+  const distanceMeters =
+    workout.totalDistance?.quantity ?? aggregated.distanceMeters ?? null;
+
+  const calories =
+    workout.totalEnergyBurned?.quantity ?? aggregated.calories ?? null;
+
+  const deviceParts = [workout.device?.manufacturer, workout.device?.model]
+    .filter(Boolean)
+    .join(' ');
+  const sourceDevice = workout.device?.name || deviceParts || null;
+
+  const sourceApp = workout.sourceRevision?.source.name ?? null;
+
+  return {
+    provider: 'healthkit',
+    provider_activity_id: workout.uuid,
+    activity_type: getActivityTypeName(workout.workoutActivityType),
+    started_at: workout.startDate.toISOString(),
+    ended_at: workout.endDate.toISOString(),
+    duration_seconds: computeDurationSeconds(workout.startDate, workout.endDate),
+    distance_meters: distanceMeters,
+    steps: aggregated.steps,
+    calories,
+    source_app: sourceApp,
+    source_device: sourceDevice,
+    raw_payload: {
+      platform: Platform.OS,
+      workoutActivityType: workout.workoutActivityType,
+      workoutActivityTypeName: getActivityTypeName(workout.workoutActivityType),
+      sourceBundleId: workout.sourceRevision?.source.bundleIdentifier ?? null,
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,6 +1721,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kingstinct/react-native-healthkit@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@kingstinct/react-native-healthkit/-/react-native-healthkit-14.0.1.tgz#ad1a5d5d79efafa2f9d2206e3024f8a0b8d9292d"
+  integrity sha512-uqjMqaiNtGCsSXGwCUAv1ujSgcnZ+fIz8d3QZdc4PG36vq2icvtY7eXdZeb60Ek8shuWZpx+jL4wsEIrL5cIqg==
+
 "@napi-rs/wasm-runtime@^1.0.7":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"


### PR DESCRIPTION
## Summary
- Adds Apple HealthKit wearable card with registration and sync support (iOS)
- Adds Google Health display in connected apps screen
- Normalizes HealthKit workout data to match backend expected format
- Updates wearable service layer, types, and hooks for multi-provider support

## Test plan
- [ ] Verify HealthKit card renders on iOS devices
- [ ] Test HealthKit registration and permission request flow
- [ ] Test workout sync from HealthKit
- [ ] Verify Health Connect card still works on Android
- [ ] Confirm connected apps screen displays all providers correctly