### PR TITLE
fix: show logo in league card

### DIFF
--- a/src/features/dashboard/components/league-card.tsx
+++ b/src/features/dashboard/components/league-card.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather';
-import { View, Pressable } from 'react-native';
+import { Image, View, Pressable } from 'react-native';
 import { Card, Chip } from 'heroui-native';
 
 import { AppText } from '../../../components/app-text';
@@ -51,14 +51,22 @@ export function LeagueCard({ league, onPress }: LeagueCardProps) {
 
           {/* Logo initials */}
           <View className="absolute top-1.5 left-1.5">
-            <View
-              className="w-6 h-6 rounded-full items-center justify-center"
-              style={{ backgroundColor: 'rgba(255,255,255,0.25)' }}
-            >
-              <AppText className="text-[10px] font-bold" style={{ color: '#fff' }}>
-                {league.name?.slice(0, 2).toUpperCase() || 'LG'}
-              </AppText>
-            </View>
+            {league.logoUrl ? (
+              <Image
+                source={{ uri: league.logoUrl }}
+                className="w-6 h-6 rounded-full"
+                style={{ backgroundColor: 'rgba(255,255,255,0.25)' }}
+              />
+            ) : (
+              <View
+                className="w-6 h-6 rounded-full items-center justify-center"
+                style={{ backgroundColor: 'rgba(255,255,255,0.25)' }}
+              >
+                <AppText className="text-[10px] font-bold" style={{ color: '#fff' }}>
+                  {league.name?.slice(0, 2).toUpperCase() || 'LG'}
+                </AppText>
+              </View>
+            )}
           </View>
 
           {/* League name */}


### PR DESCRIPTION
## Summary
The league card on the home screen was always showing initials (e.g. "Pl") instead of the league logo. The `logoUrl` field was available in the data model but never consumed by the card component.


## Type of Change
- [x] Bug fix

## Changes Made
- Updated `src/features/dashboard/components/league-card.tsx` to render the league logo image when `logoUrl` is available
- Falls back to existing initials bubble when `logoUrl` is null or empty

## How to Test
1. Log in as a league host
2. Go to the Home screen
3. Verify the league card shows the league logo instead of initials
4. Remove the logo from league settings and verify initials appear as fallback

## Screenshots / Recordings
<img width="717" height="1600" alt="WhatsApp Image 2026-05-22 at 7 24 09 PM" src="https://github.com/user-attachments/assets/f09845c8-b2c9-48e5-b629-ff2850a0c37a" />


## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task