### PR TITLE
fix: leaderboard, overview, team activity & roster UI revamp

### DIFF
--- a/src/app/(app)/team-activities.tsx
+++ b/src/app/(app)/team-activities.tsx
@@ -53,6 +53,7 @@ export default function TeamActivitiesScreen() {
   const [rejectionReason, setRejectionReason] = useState('');
   const [suspiciousProof, setSuspiciousProof] = useState(false);
   const [validatingId, setValidatingId] = useState<SubmissionId | null>(null);
+  const [showSubmissions, setShowSubmissions] = useState(false);
 
   const data = submissionsQuery.data;
   const submissions = data?.submissions ?? [];
@@ -326,38 +327,56 @@ export default function TeamActivitiesScreen() {
           />
         ) : null}
 
-        {/* Submissions Count */}
-        <SectionLabel
-          label={`${filteredSubmissions.length} Submission${filteredSubmissions.length === 1 ? '' : 's'}`}
-        />
+        {/* Submissions Count + Toggle */}
+        <View className="flex-row items-center justify-between">
+          <SectionLabel
+            label={`${filteredSubmissions.length} Submission${filteredSubmissions.length === 1 ? '' : 's'}`}
+          />
+          <Button
+            variant={showSubmissions ? 'secondary' : 'primary'}
+            size="sm"
+            onPress={() => setShowSubmissions((v) => !v)}
+          >
+            <Feather
+              name={showSubmissions ? 'eye-off' : 'eye'}
+              size={14}
+              color={showSubmissions ? mflColors.text : '#fff'}
+            />
+            <Button.Label>
+              {showSubmissions ? 'Hide' : 'Show'} Submissions
+            </Button.Label>
+          </Button>
+        </View>
 
         {/* Submissions List */}
-        {filteredSubmissions.length === 0 ? (
-          <Card className="p-5">
-            <AppText className="text-sm text-muted text-center py-6">
-              {submissions.length === 0
-                ? 'No submissions from your team yet.'
-                : 'No submissions match your filters.'}
-            </AppText>
-          </Card>
-        ) : (
-          <View className="gap-3">
-            {filteredSubmissions.map((submission) => (
-              <SubmissionValidationCard
-                key={String(submission.id)}
-                submission={submission}
-                pointsUnit={pointsUnit}
-                awardedPointsText={awardedPointsById[String(submission.id)] ?? ''}
-                canOverride={false}
-                isValidating={String(validatingId) === String(submission.id)}
-                onAwardedPointsChange={handleAwardedPointsChange}
-                onView={setSelectedSubmission}
-                onApprove={handleApprove}
-                onReject={openRejectPanel}
-              />
-            ))}
-          </View>
-        )}
+        {showSubmissions ? (
+          filteredSubmissions.length === 0 ? (
+            <Card className="p-5">
+              <AppText className="text-sm text-muted text-center py-6">
+                {submissions.length === 0
+                  ? 'No submissions from your team yet.'
+                  : 'No submissions match your filters.'}
+              </AppText>
+            </Card>
+          ) : (
+            <View className="gap-3">
+              {filteredSubmissions.map((submission) => (
+                <SubmissionValidationCard
+                  key={String(submission.id)}
+                  submission={submission}
+                  pointsUnit={pointsUnit}
+                  awardedPointsText={awardedPointsById[String(submission.id)] ?? ''}
+                  canOverride={false}
+                  isValidating={String(validatingId) === String(submission.id)}
+                  onAwardedPointsChange={handleAwardedPointsChange}
+                  onView={setSelectedSubmission}
+                  onApprove={handleApprove}
+                  onReject={openRejectPanel}
+                />
+              ))}
+            </View>
+          )
+        ) : null}
       </View>
     </ScreenScrollView>
   );

--- a/src/features/leaderboard/components/leaderboard-filter-bar.tsx
+++ b/src/features/leaderboard/components/leaderboard-filter-bar.tsx
@@ -43,18 +43,51 @@ export function LeaderboardFilterBar({
   return (
     <View className="gap-3 rounded-xl border border-default-200 bg-white p-3">
       <View className="flex-row items-center gap-2">
-        <SegmentButton
-          label="Overall"
-          icon="award"
-          selected={activeTab === 'teams'}
-          onPress={() => onTabChange('teams')}
-        />
-        <SegmentButton
-          label="Challenges"
-          icon="flag"
-          selected={activeTab === 'challenges'}
-          onPress={() => onTabChange('challenges')}
-        />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          className="flex-1"
+        >
+          <View className="flex-row gap-2 pr-2">
+            <FilterChip
+              label="All Time"
+              selected={activeTab === 'teams' && selectedWeek === 'all'}
+              onPress={() => {
+                onTabChange('teams');
+                onWeekSelect('all');
+              }}
+            />
+            {[...weekPresets].reverse().map((week) => (
+              <FilterChip
+                key={week.weekNumber}
+                label={`${week.label} (${formatDateRange(
+                  week.startDate,
+                  week.endDate,
+                )})`}
+                selected={activeTab === 'teams' && selectedWeek === week.weekNumber}
+                onPress={() => {
+                  onTabChange('teams');
+                  onWeekSelect(week.weekNumber);
+                }}
+              />
+            ))}
+            <FilterChip
+              label="Challenges"
+              icon="flag"
+              selected={activeTab === 'challenges'}
+              onPress={() => onTabChange('challenges')}
+            />
+            <FilterChip
+              label="Custom"
+              selected={activeTab === 'teams' && selectedWeek === 'custom'}
+              onPress={() => {
+                onTabChange('teams');
+                onWeekSelect('custom');
+              }}
+            />
+          </View>
+        </ScrollView>
+
         <Pressable
           className="h-10 w-10 items-center justify-center rounded-lg"
           style={{ backgroundColor: mflColors.surface }}
@@ -69,84 +102,54 @@ export function LeaderboardFilterBar({
         </Pressable>
       </View>
 
-      {activeTab === 'teams' ? (
-        <>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <View className="flex-row gap-2 pr-2">
-              <FilterChip
-                label="All Time"
-                selected={selectedWeek === 'all'}
-                onPress={() => onWeekSelect('all')}
-              />
-              {[...weekPresets].reverse().map((week) => (
-                <FilterChip
-                  key={week.weekNumber}
-                  label={`${week.label} (${formatDateRange(
-                    week.startDate,
-                    week.endDate,
-                  )})`}
-                  selected={selectedWeek === week.weekNumber}
-                  onPress={() => onWeekSelect(week.weekNumber)}
-                />
-              ))}
-              <FilterChip
-                label="Custom"
-                selected={selectedWeek === 'custom'}
-                onPress={() => onWeekSelect('custom')}
-              />
-            </View>
-          </ScrollView>
-
-          {selectedWeek === 'custom' ? (
-            <View className="gap-2">
-              <View className="flex-row gap-2">
-                <DateInput
-                  value={customStart}
-                  placeholder="Start YYYY-MM-DD"
-                  onChangeText={onCustomStartChange}
-                />
-                <DateInput
-                  value={customEnd}
-                  placeholder="End YYYY-MM-DD"
-                  onChangeText={onCustomEndChange}
-                />
-              </View>
-              <View className="flex-row gap-2">
-                <Button variant="secondary" size="sm" onPress={onReset} className="flex-1">
-                  <Button.Label>Reset</Button.Label>
-                </Button>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onPress={onApplyCustomRange}
-                  isDisabled={!customValid}
-                  className="flex-1"
-                >
-                  <Button.Label>Apply</Button.Label>
-                </Button>
-              </View>
-            </View>
-          ) : null}
-        </>
+      {activeTab === 'teams' && selectedWeek === 'custom' ? (
+        <View className="gap-2">
+          <View className="flex-row gap-2">
+            <DateInput
+              value={customStart}
+              placeholder="Start YYYY-MM-DD"
+              onChangeText={onCustomStartChange}
+            />
+            <DateInput
+              value={customEnd}
+              placeholder="End YYYY-MM-DD"
+              onChangeText={onCustomEndChange}
+            />
+          </View>
+          <View className="flex-row gap-2">
+            <Button variant="secondary" size="sm" onPress={onReset} className="flex-1">
+              <Button.Label>Reset</Button.Label>
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onPress={onApplyCustomRange}
+              isDisabled={!customValid}
+              className="flex-1"
+            >
+              <Button.Label>Apply</Button.Label>
+            </Button>
+          </View>
+        </View>
       ) : null}
     </View>
   );
 }
 
-function SegmentButton({
+function FilterChip({
   label,
   icon,
   selected,
   onPress,
 }: {
   label: string;
-  icon: keyof typeof Feather.glyphMap;
+  icon?: keyof typeof Feather.glyphMap;
   selected: boolean;
   onPress: () => void;
 }) {
   return (
     <Pressable
-      className="h-10 flex-1 flex-row items-center justify-center gap-2 rounded-lg"
+      className="flex-row items-center gap-1.5 rounded-full px-3 py-2"
       style={{
         backgroundColor: selected ? mflColors.brandLight : mflColors.surface,
         borderWidth: 1,
@@ -154,40 +157,13 @@ function SegmentButton({
       }}
       onPress={onPress}
     >
-      <Feather
-        name={icon}
-        size={15}
-        color={selected ? mflColors.brand : mflColors.textSub}
-      />
-      <AppText
-        className="text-sm font-semibold"
-        style={{ color: selected ? mflColors.brand : mflColors.textSub }}
-      >
-        {label}
-      </AppText>
-    </Pressable>
-  );
-}
-
-function FilterChip({
-  label,
-  selected,
-  onPress,
-}: {
-  label: string;
-  selected: boolean;
-  onPress: () => void;
-}) {
-  return (
-    <Pressable
-      className="rounded-full px-3 py-2"
-      style={{
-        backgroundColor: selected ? mflColors.brandLight : mflColors.surface,
-        borderWidth: 1,
-        borderColor: selected ? mflColors.brand : mflColors.border,
-      }}
-      onPress={onPress}
-    >
+      {icon ? (
+        <Feather
+          name={icon}
+          size={12}
+          color={selected ? mflColors.brand : mflColors.textSub}
+        />
+      ) : null}
       <AppText
         className="text-xs font-medium"
         style={{ color: selected ? mflColors.brand : mflColors.textSub }}

--- a/src/features/leaderboard/components/leaderboard-screen.tsx
+++ b/src/features/leaderboard/components/leaderboard-screen.tsx
@@ -16,7 +16,6 @@ import {
 } from './leaderboard-filter-bar';
 import { OverallLeaderboard } from './overall-leaderboard';
 import { ChallengeLeaderboardSection } from './challenge-leaderboard-section';
-import { RankBanner } from './rank-banner';
 import {
   calculateWeekPresets,
   formatDateRange,
@@ -64,17 +63,6 @@ export function LeaderboardScreen() {
     return calculateWeekPresets(league.start_date, league.end_date);
   }, [league?.start_date, league?.end_date]);
 
-  const userTeamId = activeLeague?.teamId ?? null;
-  const userTeamRanking = useMemo(() => {
-    if (!userTeamId || !data?.teams) return null;
-    return data.teams.find((t) => t.team_id === userTeamId) ?? null;
-  }, [data?.teams, userTeamId]);
-
-  const nextRankPoints = useMemo(() => {
-    if (!userTeamRanking || userTeamRanking.rank === 1 || !data?.teams) return undefined;
-    const nextTeam = data.teams.find((t) => t.rank === userTeamRanking.rank - 1);
-    return nextTeam?.total_points;
-  }, [data?.teams, userTeamRanking]);
 
   const roleLabel = isHost
     ? 'Host'
@@ -238,21 +226,6 @@ export function LeaderboardScreen() {
           </Animated.View>
         ) : (
           <>
-            {userTeamRanking && activeTab === 'teams' ? (
-              <Animated.View entering={FadeInDown.duration(250).delay(50)}>
-                <RankBanner
-                  rank={userTeamRanking.rank}
-                  totalTeams={data.teams.length}
-                  points={userTeamRanking.total_points}
-                  teamName={userTeamRanking.team_name}
-                  nextRankPoints={nextRankPoints}
-                  primaryColor={
-                    activeLeague?.branding?.primary_color as string | undefined
-                  }
-                />
-              </Animated.View>
-            ) : null}
-
             <Animated.View entering={FadeInDown.duration(250).delay(60)}>
               <LeaderboardFilterBar
                 activeTab={activeTab}

--- a/src/features/leaderboard/components/overall-leaderboard.tsx
+++ b/src/features/leaderboard/components/overall-leaderboard.tsx
@@ -2,6 +2,7 @@ import { View } from 'react-native';
 import { AppText } from '../../../components/app-text';
 import { ScreenState } from '../../../components/screen-state';
 import { SectionLabel } from '../../../components/section-label';
+import { mflColors } from '../../../constants/colors';
 import type { LeaderboardDataDTO } from '../types/leaderboard.dto';
 import { TeamRankingCard, IndividualRankingCard } from './ranking-cards';
 import { LeaderboardStatsBar } from './leaderboard-stats-bar';
@@ -17,6 +18,10 @@ export function OverallLeaderboard({
   const top20Count = Math.max(1, Math.ceil(data.individuals.length * 0.2));
   const topIndividuals = data.individuals.slice(0, top20Count);
 
+  const nudges = data.teams
+    .filter((t) => t.motivational_nudge)
+    .map((t) => ({ teamName: t.team_name, nudge: t.motivational_nudge! }));
+
   return (
     <View className="gap-6">
       {data.normalization?.active ? (
@@ -28,12 +33,9 @@ export function OverallLeaderboard({
       ) : null}
 
       <View className="gap-3">
-        <View>
-          <SectionLabel label="League Standings" />
-          <AppText className="mt-1 text-xs text-muted">
-            Combined activity and challenge points
-          </AppText>
-        </View>
+        <AppText className="text-xs text-muted">
+          Activity + Challenge Points
+        </AppText>
         {data.teams.length === 0 ? (
           <ScreenState
             screen="league-leaderboard"
@@ -76,6 +78,25 @@ export function OverallLeaderboard({
       </View>
 
       <LeaderboardStatsBar stats={data.stats} />
+
+      {nudges.length > 0 ? (
+        <View className="gap-2">
+          {nudges.map((item) => (
+            <View
+              key={item.teamName}
+              className="rounded-lg p-3"
+              style={{ backgroundColor: mflColors.surface }}
+            >
+              <AppText className="text-[10px] font-semibold uppercase text-muted mb-1">
+                {item.teamName}
+              </AppText>
+              <AppText className="text-xs text-muted">
+                {item.nudge}
+              </AppText>
+            </View>
+          ))}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/src/features/leaderboard/components/ranking-cards.tsx
+++ b/src/features/leaderboard/components/ranking-cards.tsx
@@ -75,12 +75,6 @@ export function TeamRankingCard({
           Activity points normalized by team size: {formatNumber(team.normalized_points)}
         </AppText>
       ) : null}
-
-      {team.motivational_nudge ? (
-        <AppText className="mt-2 text-xs text-muted">
-          {team.motivational_nudge}
-        </AppText>
-      ) : null}
     </Card>
   );
 }

--- a/src/features/leagues/components/league-overview-screen.tsx
+++ b/src/features/leagues/components/league-overview-screen.tsx
@@ -207,36 +207,33 @@ export function LeagueOverviewScreen() {
           </Card>
         )}
 
-        {/* ── Phase Indicator ────────────────────────────────────── */}
-        {phaseQuery.isLoading ? (
-          <Card variant="secondary" className="p-4" style={{ borderStyle: 'dashed' }}>
-            <AppText className="text-sm text-muted">Loading league phase...</AppText>
-          </Card>
-        ) : phaseInfo ? (
-          <Card variant="secondary" className="p-4">
-            <AppText className="text-xs font-semibold text-muted uppercase tracking-wider mb-1">
-              CURRENT PHASE
-            </AppText>
-            <View className="flex-row items-center gap-2 mb-1">
-              <AppText className="text-base font-semibold text-foreground">
-                {PHASE_LABELS[phaseInfo.phase as LeaguePhase] ?? phaseInfo.phase_label}
-              </AppText>
-            </View>
-            {phaseInfo.phase_description ? (
-              <AppText className="text-sm text-muted mb-2">
-                {phaseInfo.phase_description}
-              </AppText>
-            ) : null}
-            {phaseInfo.days_remaining != null && (
-              <View className="flex-row items-center gap-1">
-                <Feather name="clock" size={13} color={mflColors.amber} />
-                <AppText className="text-xs font-medium" style={{ color: mflColors.amber }}>
-                  {phaseInfo.days_remaining} day{phaseInfo.days_remaining !== 1 ? 's' : ''} remaining
-                </AppText>
-              </View>
+        {/* ── Quick Actions (visible without scrolling) ─────────── */}
+        {!ended && (
+          <View className="flex-row gap-2">
+            {league.startDate && league.endDate && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onPress={() => router.push('/(app)/analytics' as any)}
+                className="flex-1"
+              >
+                <Feather name="clipboard" size={14} color={mflColors.brand} />
+                <Button.Label>My Summary</Button.Label>
+              </Button>
             )}
-          </Card>
-        ) : null}
+            {!isChallengesOnly && (
+              <Button
+                variant="primary"
+                size="sm"
+                onPress={() => router.push('/(app)/(tabs)/my-activity' as any)}
+                className="flex-1"
+              >
+                <Feather name="plus-circle" size={14} color="#fff" />
+                <Button.Label>Log Activity</Button.Label>
+              </Button>
+            )}
+          </View>
+        )}
 
         {/* ── Progress Bar (active phases only) ──────────────────── */}
         {progress && !ended && ACTIVE_PHASES.includes(league.phase as LeaguePhase) && (
@@ -268,6 +265,34 @@ export function LeagueOverviewScreen() {
             </View>
           </Card>
         )}
+
+        {/* ── Phase Indicator (slim) ───────────────────────────────── */}
+        {phaseQuery.isLoading ? (
+          <Card variant="secondary" className="px-4 py-2.5" style={{ borderStyle: 'dashed' }}>
+            <AppText className="text-xs text-muted">Loading phase...</AppText>
+          </Card>
+        ) : phaseInfo ? (
+          <Card variant="secondary" className="px-4 py-2.5">
+            <View className="flex-row items-center justify-between">
+              <View className="flex-row items-center gap-2 flex-1">
+                <AppText className="text-[10px] font-semibold text-muted uppercase tracking-wider">
+                  PHASE
+                </AppText>
+                <AppText className="text-sm font-semibold text-foreground" numberOfLines={1}>
+                  {PHASE_LABELS[phaseInfo.phase as LeaguePhase] ?? phaseInfo.phase_label}
+                </AppText>
+              </View>
+              {phaseInfo.days_remaining != null && (
+                <View className="flex-row items-center gap-1">
+                  <Feather name="clock" size={12} color={mflColors.amber} />
+                  <AppText className="text-[11px] font-medium" style={{ color: mflColors.amber }}>
+                    {phaseInfo.days_remaining}d left
+                  </AppText>
+                </View>
+              )}
+            </View>
+          </Card>
+        ) : null}
 
         {/* ── League Info Section ────────────────────────────────── */}
         <View>
@@ -339,27 +364,17 @@ export function LeagueOverviewScreen() {
           </Pressable>
         )}
 
-        {/* ── Action Cards (Report & Donate) ─────────────────────── */}
-        {!ended && (
+        {/* ── Rest Day Donation ─────────────────────────────────── */}
+        {!ended && league.restDays > 0 && (
           <View>
             <SectionLabel label="ACTIONS" />
             <Card variant="secondary" className="mt-1">
-              {league.startDate && league.endDate && (
-                <ActionRow
-                  icon="clipboard"
-                  label="My League Summary"
-                  subtitle="View your activity report"
-                  onPress={() => router.push('/(app)/analytics' as any)}
-                />
-              )}
-              {league.restDays > 0 && (
-                <ActionRow
-                  icon="gift"
-                  label="Donate Rest Days"
-                  subtitle="Gift rest days to a teammate"
-                  onPress={() => router.push('/(app)/rest-day-donations' as any)}
-                />
-              )}
+              <ActionRow
+                icon="gift"
+                label="Donate Rest Days"
+                subtitle="Gift rest days to a teammate"
+                onPress={() => router.push('/(app)/rest-day-donations' as any)}
+              />
             </Card>
           </View>
         )}

--- a/src/features/team/components/team-view-roster.tsx
+++ b/src/features/team/components/team-view-roster.tsx
@@ -1,17 +1,10 @@
-import { useMemo } from 'react';
 import { View } from 'react-native';
-import { Avatar, Card, Chip } from 'heroui-native';
+import { Card } from 'heroui-native';
 import Feather from '@expo/vector-icons/Feather';
 import { AppText } from '../../../components/app-text';
 import { SectionLabel } from '../../../components/section-label';
 import { mflColors } from '../../../constants/colors';
 import type { TeamMember } from '../types/team.model';
-
-function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length >= 2) return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
-  return name.substring(0, 2).toUpperCase();
-}
 
 function capitalizeName(name: string): string {
   if (!name) return '';
@@ -21,8 +14,8 @@ function capitalizeName(name: string): string {
     .join(' ');
 }
 
-/** Top-3 left-border colors matching web's gold/silver/bronze */
-const RANK_BORDER_COLORS = ['#F59E0B', '#94A3B8', '#B45309'] as const;
+/** Top-3 rank colors matching web's gold/silver/bronze */
+const RANK_COLORS = ['#F59E0B', '#94A3B8', '#B45309'] as const;
 
 interface TeamViewRosterProps {
   members: TeamMember[];
@@ -35,170 +28,112 @@ export function TeamViewRoster({
   members,
   showRR,
   showRestDays,
-  isCaptain = false,
 }: TeamViewRosterProps) {
-  const highestPoints = useMemo(
-    () => Math.max(...members.map((m) => m.points || 0), 1),
-    [members],
-  );
-
   return (
     <View className="gap-2">
       <SectionLabel label={`Team Members (${members.length})`} />
 
       {members.length > 0 ? (
-        members.map((member, index) => {
-          const isAtRisk = member.points === 0;
-          const progressPct =
-            highestPoints > 0 ? (member.points / highestPoints) * 100 : 0;
-          const rankBorderColor =
-            index < 3 ? RANK_BORDER_COLORS[index] : undefined;
-
-          return (
-            <Card
-              key={member.leagueMemberId}
-              className="p-4"
-              style={
-                rankBorderColor
-                  ? { borderLeftWidth: 3, borderLeftColor: rankBorderColor }
-                  : undefined
-              }
+        <Card className="p-0 overflow-hidden">
+          {/* Table Header */}
+          <View
+            className="flex-row items-center px-4 py-2.5"
+            style={{ backgroundColor: mflColors.surface }}
+          >
+            <AppText className="flex-1 text-[11px] font-semibold uppercase text-muted tracking-wider">
+              Player
+            </AppText>
+            {showRR && (
+              <AppText
+                className="text-[11px] font-semibold uppercase text-muted tracking-wider text-right"
+                style={{ width: 56 }}
+              >
+                RR
+              </AppText>
+            )}
+            <AppText
+              className="text-[11px] font-semibold uppercase text-muted tracking-wider text-right"
+              style={{ width: 64 }}
             >
-              {/* Top: avatar + name + stats */}
-              <View className="flex-row items-start gap-3">
-                {/* Avatar with captain badge */}
-                <View>
-                  <Avatar
-                    size="md"
-                    alt={member.username}
-                    style={
-                      member.isCaptain
-                        ? { borderWidth: 2, borderColor: mflColors.amber }
-                        : isAtRisk
-                          ? { borderWidth: 2, borderColor: mflColors.danger }
-                          : undefined
-                    }
-                  >
-                    {member.profilePictureUrl ? (
-                      <Avatar.Image
-                        source={{ uri: member.profilePictureUrl }}
-                      />
-                    ) : null}
-                    <Avatar.Fallback>
-                      <AppText
-                        className="text-xs font-semibold"
-                        style={{ color: mflColors.brand }}
-                      >
-                        {getInitials(member.username)}
-                      </AppText>
-                    </Avatar.Fallback>
-                  </Avatar>
-                  {member.isCaptain && (
-                    <View
-                      className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full items-center justify-center"
-                      style={{ backgroundColor: mflColors.amber }}
-                    >
-                      <Feather name="award" size={10} color={mflColors.white} />
-                    </View>
-                  )}
-                </View>
+              Pts
+            </AppText>
+            {showRestDays && (
+              <AppText
+                className="text-[11px] font-semibold uppercase text-muted tracking-wider text-right"
+                style={{ width: 48 }}
+              >
+                Rest
+              </AppText>
+            )}
+          </View>
 
-                {/* Name + role + at-risk chip */}
-                <View className="flex-1 gap-1">
-                  <View className="flex-row items-center gap-2 flex-wrap">
-                    <AppText
-                      className="text-sm font-semibold text-foreground"
-                      numberOfLines={1}
-                    >
-                      {capitalizeName(member.username)}
-                    </AppText>
-                    {member.isCaptain ? (
-                      <Chip size="sm" variant="soft">
-                        <Chip.Label>Captain</Chip.Label>
-                      </Chip>
-                    ) : (
-                      <AppText className="text-[10px] text-muted">
-                        Player
-                      </AppText>
-                    )}
-                  </View>
-                  {isAtRisk && isCaptain && (
-                    <View
-                      className="flex-row items-center gap-1 self-start rounded-full px-2 py-0.5"
-                      style={{ backgroundColor: mflColors.dangerLight }}
-                    >
-                      <Feather
-                        name="alert-triangle"
-                        size={10}
-                        color={mflColors.danger}
-                      />
-                      <AppText
-                        className="text-[10px] font-semibold"
-                        style={{ color: mflColors.danger }}
-                      >
-                        At risk
-                      </AppText>
-                    </View>
-                  )}
-                </View>
+          {/* Table Rows */}
+          {members.map((member, index) => {
+            const rankColor = index < 3 ? RANK_COLORS[index] : undefined;
 
-                {/* Stats */}
-                <View className="items-end gap-0.5">
-                  <AppText
-                    className="text-sm font-bold"
-                    style={{ color: mflColors.brand }}
-                  >
-                    {member.points}
+            return (
+              <View
+                key={member.leagueMemberId}
+                className="flex-row items-center px-4 py-3"
+                style={{
+                  borderTopWidth: 1,
+                  borderTopColor: mflColors.border,
+                  ...(rankColor
+                    ? { borderLeftWidth: 3, borderLeftColor: rankColor }
+                    : {}),
+                }}
+              >
+                {/* Player Name */}
+                <View className="flex-1 flex-row items-center gap-2">
+                  <AppText className="text-xs text-muted" style={{ width: 20 }}>
+                    {index + 1}
                   </AppText>
-                  {showRR && (
-                    <View className="flex-row items-center gap-0.5">
-                      <Feather name="star" size={10} color={mflColors.amber} />
-                      <AppText className="text-[10px] text-muted">
-                        {member.avgRr.toFixed(2)}
-                      </AppText>
-                    </View>
+                  <AppText
+                    className="text-sm text-foreground flex-1"
+                    numberOfLines={1}
+                    style={member.isCaptain ? { fontWeight: '700' } : undefined}
+                  >
+                    {capitalizeName(member.username)}
+                  </AppText>
+                  {member.isCaptain && (
+                    <Feather name="award" size={12} color={mflColors.amber} />
                   )}
-                  {showRestDays && (
-                    <AppText className="text-[10px] text-muted">
-                      Rest: {member.restDaysUsed}
-                    </AppText>
+                  {member.points === 0 && (
+                    <Feather name="alert-triangle" size={12} color={mflColors.danger} />
                   )}
                 </View>
-              </View>
 
-              {/* Contribution bar */}
-              <View className="mt-3">
-                <AppText
-                  className="text-[9px] uppercase mb-1"
-                  style={{
-                    color: mflColors.textMuted,
-                    letterSpacing: 0.8,
-                  }}
-                >
-                  CONTRIBUTION
-                </AppText>
-                {progressPct > 0 ? (
-                  <View
-                    className="h-1.5 rounded-full overflow-hidden"
-                    style={{ backgroundColor: mflColors.inkLight }}
+                {/* RR */}
+                {showRR && (
+                  <AppText
+                    className="text-sm text-right"
+                    style={{ width: 56, color: mflColors.textSub }}
                   >
-                    <View
-                      className="h-full rounded-full"
-                      style={{
-                        width: `${progressPct}%`,
-                        backgroundColor: mflColors.brand,
-                      }}
-                    />
-                  </View>
-                ) : (
-                  <AppText className="text-[10px] text-muted">
-                    No activity yet
+                    {member.avgRr.toFixed(2)}
+                  </AppText>
+                )}
+
+                {/* Points */}
+                <AppText
+                  className="text-sm font-semibold text-right"
+                  style={{ width: 64, color: mflColors.brand }}
+                >
+                  {member.points}
+                </AppText>
+
+                {/* Rest Days */}
+                {showRestDays && (
+                  <AppText
+                    className="text-sm text-right"
+                    style={{ width: 48, color: mflColors.textSub }}
+                  >
+                    {member.restDaysUsed}
                   </AppText>
                 )}
               </View>
-            </Card>
-          );
-        })
+            );
+          })}
+        </Card>
       ) : (
         <Card className="p-4">
           <View className="py-6 items-center">


### PR DESCRIPTION
## Summary
Client-raised UI/UX changes across 4 mobile screens:

- **Leaderboard**: Removed RankBanner, merged Overall/Challenges tabs into unified chip row, removed duplicate "League Standings" heading, moved AI nudges below table, updated subtitle to "Activity + Challenge Points"
- **League Overview**: Slimmed CURRENT PHASE card to single-row layout, moved below progress bar, surfaced "My Summary" and "Log Activity" buttons above fold
- **Team Activity**: Hidden submission list behind Show/Hide toggle button (not shown by default)
- **My Team Roster**: Converted card-based roster to aligned table format with # / Player / RR / Pts columns

## Files Changed
- `src/features/leaderboard/components/leaderboard-screen.tsx`
- `src/features/leaderboard/components/leaderboard-filter-bar.tsx`
- `src/features/leaderboard/components/overall-leaderboard.tsx`
- `src/features/leaderboard/components/ranking-cards.tsx`
- `src/features/leagues/components/league-overview-screen.tsx`
- `src/app/(app)/team-activities.tsx`
- `src/features/team/components/team-view-roster.tsx`

## Test plan
- [ ] Leaderboard: verify unified chip row switches between All Time/Week/Challenges/Custom correctly
- [ ] Leaderboard: verify no RankBanner appears at top
- [ ] Leaderboard: verify AI nudges appear below team/individual tables
- [ ] Overview: verify My Summary and Log Activity buttons visible without scroll
- [ ] Overview: verify phase card is slim single-row layout
- [ ] Team Activity: verify submissions hidden by default, revealed on "Show Submissions" tap
- [ ] My Team: verify roster displays as table with aligned columns