### PR TITLE
feat: show challenge count in league templates

### DIFF
--- a/src/features/leagues/quick-start/quick-start.types.ts
+++ b/src/features/leagues/quick-start/quick-start.types.ts
@@ -13,6 +13,7 @@ export interface TemplateConfig {
   subtitle: string;
   duration: number;
   activities: number;
+  challenges: number;
   restDays: number;
   activityList: string[];
 }
@@ -53,6 +54,7 @@ export interface WizardResult {
   invite_code: string;
   teams_created: number;
   activities_added: number;
+  challenges_added: number;
   start_date: string;
   end_date: string;
   team_invites: TeamInvite[];
@@ -76,18 +78,20 @@ export const TEMPLATES: TemplateConfig[] = [
   {
     id: '40_day',
     title: '40-Day League',
-    subtitle: 'Perfect for a focused fitness sprint. 40 days, 5 core activities.',
+    subtitle: 'Perfect for a focused fitness sprint. 40 days, 5 activities, 3 challenges.',
     duration: 40,
     activities: 5,
+    challenges: 3,
     restDays: 1,
     activityList: ['Running', 'Walking', 'Cycling', 'Yoga', 'Gym'],
   },
   {
     id: '60_day',
     title: '60-Day League',
-    subtitle: 'Full fitness journey. 60 days, all activities included.',
+    subtitle: 'Full fitness journey. 60 days, 8 activities, 4 challenges included.',
     duration: 60,
     activities: 8,
+    challenges: 4,
     restDays: 1,
     activityList: [
       'Running', 'Walking', 'Cycling', 'Yoga', 'Gym',
@@ -96,11 +100,12 @@ export const TEMPLATES: TemplateConfig[] = [
   },
   {
     id: '90_day_pfl',
-    title: '90-Day PFL Format',
+    title: '90-Day League',
     subtitle:
-      'The full Pristine Fitness League format. 90 days, 10 activities including Golf & Steps.',
+      'The ultimate fitness challenge. 90 days, 10 activities, 5 challenges.',
     duration: 90,
     activities: 10,
+    challenges: 5,
     restDays: 1,
     activityList: [
       'Running', 'Walking', 'Cycling', 'Yoga', 'Gym',

--- a/src/features/leagues/quick-start/review-step.tsx
+++ b/src/features/leagues/quick-start/review-step.tsx
@@ -137,6 +137,7 @@ export function StepReviewLaunch({ data, onBack, onSubmit, loading, result }: Pr
         <View className="flex-row gap-2">
           <SuccessStat value={String(result.teams_created)} label="Teams" />
           <SuccessStat value={String(result.activities_added)} label="Activities" />
+          <SuccessStat value={String(result.challenges_added)} label="Challenges" />
           <SuccessStat value={String(data.duration)} label="Days" />
         </View>
       </View>

--- a/src/features/leagues/quick-start/template-step.tsx
+++ b/src/features/leagues/quick-start/template-step.tsx
@@ -139,9 +139,10 @@ export function StepLeagueType({ data, onUpdate, onNext }: Props) {
             </View>
             <AppText className="text-xs text-muted mb-3">{template.subtitle}</AppText>
 
-            <View className="flex-row gap-3 mb-3">
+            <View className="flex-row gap-2 mb-3">
               <StatBadge icon="calendar" value={template.duration} label="Days" />
               <StatBadge icon="activity" value={template.activities} label="Activities" />
+              <StatBadge icon="target" value={template.challenges} label="Challenges" />
               <StatBadge icon="coffee" value={template.restDays} label="Rest/wk" />
             </View>
 


### PR DESCRIPTION
## Summary
- Template cards now display challenge count (3/4/5) alongside days/activities/rest
- Success screen shows `challenges_added` count from API response
- Renamed "90-Day PFL Format" to generic "90-Day League"
- Parity with web PR adminmfl/mfl#300 (backend auto-deploys challenges)

## Files changed
- `src/features/leagues/quick-start/quick-start.types.ts` — Added `challenges` to TemplateConfig, `challenges_added` to WizardResult
- `src/features/leagues/quick-start/template-step.tsx` — Added Challenges stat badge in template cards
- `src/features/leagues/quick-start/review-step.tsx` — Shows challenges count in success summary

## Test plan
- [ ] Verify template cards show 4 stat badges (Days, Activities, Challenges, Rest/wk)
- [ ] Create a league from 40-day template — verify success screen shows "3 Challenges"
- [ ] Create a league from 60-day template — verify success screen shows "4 Challenges"
- [ ] Navigate to challenges tab — verify challenges are auto-created