### PR TITLE
fix: reupload image

### DIFF
--- a/src/app/(app)/reupload-submission.tsx
+++ b/src/app/(app)/reupload-submission.tsx
@@ -106,11 +106,11 @@ export default function ReuploadSubmissionScreen() {
     if (!result.canceled && result.assets?.[0]) {
       const asset = result.assets[0];
       const fileName = asset.fileName ?? `proof_${Date.now()}.jpg`;
-      const fileType = asset.type ?? 'image/jpeg';
+      const fileType = (asset as { mimeType?: string }).mimeType ?? 'image/jpeg';
       setProofImage({
         uri: asset.uri,
         name: fileName,
-        type: fileType.startsWith('image/') ? fileType : `image/${fileType}`,
+        type: fileType,
       });
     }
   }, []);


### PR DESCRIPTION
## Summary
The mobile reupload screen was failing to upload proof images due to an incorrect MIME type property being used when building the file object for upload.

## Type of Change
[x] Bug fix

## Changes Made
- Fixed MIME type property on proof image object — now uses (asset as { mimeType?: string }).mimeType ?? 'image/jpeg' instead of asset.type when building the file for upload to /api/upload/proof

## How to Test
1. Log in as a league member on mobile
2. Navigate to My Submissions and find a rejected submission
3. Tap Reupload and select a proof image
4. Tap Resubmit
5. Verify /api/upload/proof returns 200 and the reupload proceeds without "Upload Failed" error


## Checklist
[x] I have tested this locally and it works
[x] pnpm build passes with no errors
[x] No console.log or commented-out code left behind
[x] My branch is up to date with develop
[x] I have not modified any files outside the scope of this task