### PR TITLE
fix: wire team-activities route and add navigation from my-team screen

### DIFF
--- a/src/app/(app)/(tabs)/my-team.tsx
+++ b/src/app/(app)/(tabs)/my-team.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { View, Modal, Pressable, ScrollView, TextInput } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { Avatar, Button, Card, Chip, Separator, Tabs } from 'heroui-native';
+import { useRouter } from 'expo-router';
 import { AppText } from '../../../components/app-text';
 import { ScreenScrollView } from '../../../components/screen-scroll-view';
 import { DarkHeaderCard } from '../../../components/dark-header-card';
@@ -28,6 +29,7 @@ function getInitials(name: string): string {
 }
 
 export default function MyTeamScreen() {
+  const router = useRouter();
   const { activeLeague } = useLeagueContext();
   const { isCaptain, isViceCaptain, isHost } = useRole();
   const [activeTab, setActiveTab] = useState<TabKey>('Roster');
@@ -131,6 +133,7 @@ export default function MyTeamScreen() {
             teamId={teamId}
             unallocatedMembers={unallocatedMembers ?? []}
             onMembersChanged={handleRefresh}
+            onOpenTeamActivities={() => router.push('/(app)/team-activities' as any)}
           />
         ) : (
           <TeamsTab teams={teams ?? []} />
@@ -188,6 +191,7 @@ interface RosterTabProps {
   teamId: string | null;
   unallocatedMembers: LeagueMember[];
   onMembersChanged: () => void;
+  onOpenTeamActivities: () => void;
 }
 
 function RosterTab({
@@ -203,6 +207,7 @@ function RosterTab({
   teamId,
   unallocatedMembers,
   onMembersChanged,
+  onOpenTeamActivities,
 }: RosterTabProps) {
   const { activeLeague } = useLeagueContext();
   const [searchQuery, setSearchQuery] = useState('');
@@ -282,15 +287,23 @@ function RosterTab({
         </View>
       )}
 
-      {/* Unallocated Members Button */}
-      {isLeader && unallocatedMembers.length > 0 && (
-        <Button
-          variant="secondary"
-          size="md"
-          onPress={() => setUnallocatedModalOpen(true)}
-        >
-          <Button.Label>Unallocated Members ({unallocatedMembers.length})</Button.Label>
-        </Button>
+      {/* Leader actions */}
+      {isLeader && (
+        <View className="gap-2">
+          {unallocatedMembers.length > 0 && (
+            <Button
+              variant="secondary"
+              size="md"
+              onPress={() => setUnallocatedModalOpen(true)}
+            >
+              <Button.Label>Unallocated Members ({unallocatedMembers.length})</Button.Label>
+            </Button>
+          )}
+          <Button variant="secondary" size="md" onPress={onOpenTeamActivities}>
+            <Feather name="clipboard" size={16} color={mflColors.text} />
+            <Button.Label>Team Activities</Button.Label>
+          </Button>
+        </View>
       )}
 
       {/* Search (show when >5 members) */}

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -381,6 +381,7 @@ export default function AppLayout() {
           <Stack.Screen name="analytics" />
           <Stack.Screen name="governor" />
           <Stack.Screen name="submission-validation" />
+          <Stack.Screen name="team-activities" />
           <Stack.Screen name="rest-day-donations" />
           <Stack.Screen name="manual-entry" />
           <Stack.Screen name="settings" />


### PR DESCRIPTION
## Summary
`team-activities.tsx` existed but was never reachable in the app — no navigation entry point and no stack registration.


## Type of Change
- [x] Bug fix

## Changes Made
- Added "Team Activities" button in `my-team.tsx` for leaders/captains to navigate to the team activity screen
- Registered `team-activities` as a named route in `_layout.tsx`

## How to Test
1. Log in as a captain or league host on Android
2. Go to My Team tab
3. Verify "Team Activities" button appears
4. Tap it and verify the team activity screen loads with submissions toggle

## Screenshots / Recordings
<img width="717" height="1600" alt="WhatsApp Image 2026-05-24 at 4 20 22 AM" src="https://github.com/user-attachments/assets/ef330b45-565b-438c-af88-fbf0003382c2" />


## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task