### PR TITLE
fix: add League Overview navigation entry point from dashboard

### DIFF
--- a/src/app/(app)/(tabs)/dashboard.tsx
+++ b/src/app/(app)/(tabs)/dashboard.tsx
@@ -158,6 +158,18 @@ export default function DashboardScreen() {
           </Pressable>
         )}
 
+        {activeLeague && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onPress={() => router.push('/(app)/league-overview' as any)}
+            className="self-start"
+          >
+            <Feather name="grid" size={14} color={mflColors.brand} />
+            <Button.Label>League Overview</Button.Label>
+          </Button>
+        )}
+
         {/* ── My Leagues Section (matches web) ─────────────────── */}
         <View>
           <SectionLabel


### PR DESCRIPTION
## Summary
`league-overview.tsx` was registered as a stack screen but had no navigation entry point in the app — users could never reach the League Overview screen or its "My Summary", "Log Activity", and phase card UI.


## Type of Change
- [x] Bug fix

## Changes Made
- Added a "League Overview" button on the dashboard screen under the active league selector that routes to `/(app)/league-overview`

## How to Test
1. Log in and ensure you have an active league
2. Go to the Home/Dashboard tab
3. Verify "League Overview" button appears under the league selector
4. Tap it and verify the League Overview screen loads with "My Summary", "Log Activity" buttons and the slim phase card visible

## Screenshots / Recordings
<img width="717" height="1600" alt="WhatsApp Image 2026-05-24 at 3 36 26 PM" src="https://github.com/user-attachments/assets/5f001c82-22ba-49f8-89db-c73d666cd4fc" />


## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task