### PR TITLE
fix: render empty state outside inverted FlatList to prevent upside-d…

### DIFF
--- a/src/app/(app)/(tabs)/coach.tsx
+++ b/src/app/(app)/(tabs)/coach.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   View,
   TextInput,
@@ -158,7 +158,8 @@ export default function CoachTab() {
   const [input, setInput] = useState('');
   const flatListRef = useRef<FlatList>(null);
 
-  const messages = useMemo(() => [...(history ?? [])].reverse(), [history]);
+  // useCoachHistory returns newest-first for inverted FlatList.
+  const messages = history ?? [];
 
   const handleSend = useCallback(
     (text?: string) => {
@@ -213,27 +214,28 @@ export default function CoachTab() {
       />
 
       {/* Chat */}
-      <FlatList
-        ref={flatListRef}
-        data={messages}
-        keyExtractor={(item) => item.messageId}
-        renderItem={renderItem}
-        inverted
-        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
-        showsVerticalScrollIndicator={false}
-        ListEmptyComponent={
-          <View
-            className="items-center justify-center"
-            style={{ paddingVertical: 48, transform: [{ scaleY: -1 }] }}
-          >
+      <View className="flex-1">
+        {messages.length === 0 ? (
+          <View className="flex-1 items-center justify-center px-5 py-12">
             <Feather name="cpu" size={32} color={mflColors.textMuted} />
             <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
             <AppText className="text-xs text-muted mt-1 text-center px-8">
               Ask about your performance, strategy, or league standings. Everything here is private.
             </AppText>
           </View>
-        }
-      />
+        ) : (
+          <FlatList
+            ref={flatListRef}
+            data={messages}
+            keyExtractor={(item) => item.messageId}
+            renderItem={renderItem}
+            inverted
+            contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
+      </View>
 
       {/* Sending indicator */}
       {sendMutation.isPending && (

--- a/src/app/(app)/ai-coach.tsx
+++ b/src/app/(app)/ai-coach.tsx
@@ -222,24 +222,27 @@ export default function AiCoachScreen() {
       </ScrollView>
 
       {/* Chat history */}
-      <FlatList
-        data={messages}
-        renderItem={renderMessage}
-        keyExtractor={keyExtractor}
-        inverted
-        contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 12 }}
-        showsVerticalScrollIndicator={false}
-        keyboardShouldPersistTaps="handled"
-        ListEmptyComponent={
-          <View className="items-center justify-center" style={{ paddingVertical: 48, transform: [{ scaleY: -1 }] }}>
+      <View className="flex-1">
+        {(messages?.length ?? 0) === 0 ? (
+          <View className="flex-1 items-center justify-center px-4 py-12">
             <Feather name="cpu" size={32} color={mflColors.textMuted} />
             <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
             <AppText className="text-xs text-muted mt-1 text-center px-8">
               Ask about your performance, strategy, or league standings. Everything here is private.
             </AppText>
           </View>
-        }
-      />
+        ) : (
+          <FlatList
+            data={messages}
+            renderItem={renderMessage}
+            keyExtractor={keyExtractor}
+            inverted
+            contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 12 }}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
+      </View>
 
       {/* Sending indicator */}
       {sendMutation.isPending && (

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   Pressable,
   RefreshControl,
+  ScrollView,
   View,
   type ListRenderItemInfo,
 } from 'react-native';
@@ -321,6 +322,26 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
             actionLabel="Retry"
             onAction={() => messagesQuery.refetch()}
           />
+        ) : messages.length === 0 ? (
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{
+              flexGrow: 1,
+              justifyContent: 'center',
+              paddingHorizontal: 16,
+              paddingVertical: 48,
+            }}
+            refreshControl={
+              <RefreshControl refreshing={refreshing} onRefresh={refresh} />
+            }
+            keyboardShouldPersistTaps="handled"
+          >
+            <AppText className="text-sm text-muted text-center">
+              {filter === 'all'
+                ? 'No messages yet.'
+                : `No ${FILTER_OPTIONS.find((option) => option.value === filter)?.label.toLowerCase()} messages.`}
+            </AppText>
+          </ScrollView>
         ) : (
           <FlatList
             ref={flatListRef}
@@ -334,23 +355,9 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
             contentContainerStyle={{
               paddingHorizontal: 16,
               paddingVertical: 12,
-              flexGrow: messages.length === 0 ? 1 : undefined,
             }}
             showsVerticalScrollIndicator={false}
             keyboardShouldPersistTaps="handled"
-            ListEmptyComponent={
-              <View
-                className="flex-1 items-center justify-center py-12"
-                style={{ transform: [{ scaleY: -1 }] }}
-              >
-              
-              <AppText className="text-sm text-muted text-center">
-                  {filter === 'all'
-                    ? 'No messages yet.'
-                    : `No ${FILTER_OPTIONS.find((option) => option.value === filter)?.label.toLowerCase()} messages.`}
-                </AppText>
-              </View>
-            }
           />
         )}
       </View>


### PR DESCRIPTION
## Summary

Fix chat empty state text rendering upside-down — render empty UI outside inverted FlatList instead of using counter-transforms.

## What was broken

Chat screens (AI Coach, Team Chat, Coach tab) showed empty state text upside-down when no messages existed. The `inverted` FlatList flips its children, and the `ListEmptyComponent` counter-transform (`scaleY: -1`) didn't reliably undo the inversion across devices and render cycles.

## Root Cause

Two things conflicted:
1. Bad merge added `scaleY: -1` on the entire FlatList instead of using `inverted`, flipping every row
2. Later fix restored `inverted` and counter-flipped `ListEmptyComponent`, but the counter-transform didn't work reliably

## What was fixed

When there are **no** messages, render the empty UI **outside** the inverted `FlatList` (plain `View`/`ScrollView`). When there **are** messages, use `inverted` only — no transforms on any rows.

Also fixed **coach tab** double-reversing history (`useCoachHistory` already returns newest-first; the tab was reversing again).


## Tested

- AI Coach (empty) — "Your Private AI Coach" reads correctly
- Team Chat (empty) — "No messages yet." reads correctly, pull-to-refresh works
- Send a message — bubbles appear normal, newest at bottom
- No native rebuild needed — JS only

## Impact

- **Mobile** — chat screens (AI Coach, Team Chat, Coach tab)

## Risk

- Low — only changes empty state rendering pattern, message rendering untouched

## Files Modified

- `src/app/(app)/(tabs)/coach.tsx`
- `src/app/(app)/ai-coach.tsx`
- `src/features/messaging/components/team-messaging-screen.tsx`