### PR TITLE
fix: manual workout entries reflect immediately on leaderboard

### DIFF
--- a/src/features/leaderboard/components/leaderboard-screen.tsx
+++ b/src/features/leaderboard/components/leaderboard-screen.tsx
@@ -1,4 +1,5 @@
 import Feather from '@expo/vector-icons/Feather';
+import { useFocusEffect } from '@react-navigation/native';
 import { useCallback, useMemo, useState } from 'react';
 import { Alert, View } from 'react-native';
 import Animated, { FadeInDown } from 'react-native-reanimated';
@@ -53,6 +54,12 @@ export function LeaderboardScreen() {
   const handleRefresh = useCallback(async () => {
     await leaderboardQuery.refetch();
   }, [leaderboardQuery]);
+
+  useFocusEffect(
+    useCallback(() => {
+      leaderboardQuery.refetch();
+    }, [leaderboardQuery]),
+  );
 
   const data = leaderboardQuery.data;
   const league = data?.league;

--- a/src/features/manual-entry/hooks/use-save-manual-entry.ts
+++ b/src/features/manual-entry/hooks/use-save-manual-entry.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { queryKeys } from '../../../core/config';
 import { saveManualEntry } from '../services/manual-entry.service';
 import type { ManualEntrySaveRequestDTO } from '../types/manual-entry';
 
@@ -23,7 +24,7 @@ export function useSaveManualEntry() {
         queryKey: ['leagues', leagueId, 'submissions'],
       });
       queryClient.invalidateQueries({
-        queryKey: ['leagues', leagueId, 'leaderboard'],
+        queryKey: queryKeys.leagues.leaderboard(leagueId),
       });
     },
   });


### PR DESCRIPTION
## Summary
Manual workout entries added by host were not reflecting immediately on the leaderboard due to a query key mismatch on cache invalidation and no focus-based refetch on the leaderboard screen.


## Type of Change
- [x] Bug fix

## Changes Made
- Fixed leaderboard query invalidation in `use-save-manual-entry.ts` to use `queryKeys.leagues.leaderboard(leagueId)` instead of a raw key array that didn't match the actual cached query key
- Added `useFocusEffect` to `leaderboard-screen.tsx` so the leaderboard refetches whenever the user navigates back to it

## How to Test
1. Log in as a host/governor on mobile
2. Navigate to the leaderboard and note the current scores
3. Add a manual workout entry for a member
4. Navigate back to the leaderboard
5. Verify the leaderboard updates immediately without needing to pull to refresh


## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task