### PR TITLE
fix: invalidate analytics query after submission approve/reject

### DIFF
--- a/src/features/validation/hooks/use-validate-submission.ts
+++ b/src/features/validation/hooks/use-validate-submission.ts
@@ -21,6 +21,7 @@ export function useValidateSubmission() {
       queryClient.invalidateQueries({ queryKey: queryKeys.leagues.submissions(leagueId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.leagues.teamSubmissions(leagueId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.leagues.leaderboard(leagueId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.leagues.analytics(leagueId) });
     },
   });
 }


### PR DESCRIPTION
## Summary
Analytics was showing stale data after a submission was approved or rejected because the validate mutation was not invalidating the analytics React Query cache.


## Type of Change
- [x] Bug fix

## Changes Made
- Added `queryClient.invalidateQueries` for analytics query key in `src/features/validation/hooks/use-validate-submission.ts`

## How to Test
1. Log in as a league member and submit a workout
2. As host, approve or reject the submission
3. Navigate to Analytics immediately
4. Verify the data reflects the updated submission status without needing to wait or pull to refresh

## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task