### PR TITLE
Fix/ai coach message order markdown

### DIFF
--- a/src/app/(app)/(tabs)/coach.tsx
+++ b/src/app/(app)/(tabs)/coach.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   View,
   TextInput,
+  FlatList,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  type ListRenderItemInfo,
 } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -25,7 +27,58 @@ import { SuggestedQuestions } from '../../../features/ai-coach/components/sugges
 import { MilestoneCard } from '../../../features/ai-coach/components/milestone-card';
 import { RecoveryCard } from '../../../features/ai-coach/components/recovery-card';
 import { WeeklyInsightCard } from '../../../features/ai-coach/components/weekly-insight-card';
-import { CoachChatList } from '../../../features/ai-coach/components/coach-chat-list';
+import type { AiCoachMessage } from '../../../features/ai-coach/types/ai-coach.model';
+import { renderCoachMarkdown } from '../../../features/ai-coach/utils/render-coach-markdown';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+// ─── Message Bubble ─────────────────────────────────────────────────────────
+
+function MessageBubble({ message, isOwn }: { message: AiCoachMessage; isOwn: boolean }) {
+  if (isOwn) {
+    return (
+      <View className="items-end mb-3">
+        <View className="rounded-2xl px-4 py-3 max-w-[80%]" style={{ backgroundColor: mflColors.brand }}>
+          <AppText className="text-sm" style={{ color: '#fff' }}>{message.content}</AppText>
+        </View>
+        <AppText className="text-[10px] text-muted mt-1">{formatTimestamp(message.createdAt)}</AppText>
+      </View>
+    );
+  }
+
+  return (
+    <View className="items-start mb-3">
+      <View className="flex-row items-start gap-2 max-w-[85%]">
+        <View className="w-7 h-7 rounded-full items-center justify-center mt-1" style={{ backgroundColor: mflColors.brand }}>
+          <AppText className="text-xs font-bold" style={{ color: '#fff' }}>AI</AppText>
+        </View>
+        <View className="bg-card rounded-2xl px-4 py-3 flex-1 border border-default-200" style={{ borderLeftWidth: 3, borderLeftColor: mflColors.brand }}>
+          <AppText className="text-sm text-foreground">
+            {renderCoachMarkdown(message.content, {
+              base: { fontSize: 14, color: mflColors.text },
+              bold: { fontWeight: '700' },
+              italic: { fontStyle: 'italic' },
+              code: { fontFamily: 'monospace', fontSize: 13 },
+            })}
+          </AppText>
+        </View>
+      </View>
+      <AppText className="text-[10px] text-muted mt-1 ml-9">{formatTimestamp(message.createdAt)}</AppText>
+    </View>
+  );
+}
 
 // ─── Insights Panel (horizontal scroll on mobile) ───────────────────────────
 
@@ -111,6 +164,9 @@ export default function CoachTab() {
   const sendMutation = useSendCoachMessage();
 
   const [input, setInput] = useState('');
+  const flatListRef = useRef<FlatList>(null);
+
+  // useCoachHistory returns newest-first for inverted FlatList.
   const messages = history ?? [];
 
   const handleSend = useCallback(
@@ -121,6 +177,13 @@ export default function CoachTab() {
       sendMutation.mutate({ leagueId, message: msg });
     },
     [input, leagueId, sendMutation],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<AiCoachMessage>) => (
+      <MessageBubble message={item} isOwn={item.role === 'user'} />
+    ),
+    [],
   );
 
   if (!activeLeague) {
@@ -158,9 +221,28 @@ export default function CoachTab() {
         isSending={sendMutation.isPending}
       />
 
-      {/* Chat — chronological list (oldest → newest), scroll pinned to bottom */}
+      {/* Chat */}
       <View className="flex-1">
-        <CoachChatList messages={messages} />
+        {messages.length === 0 ? (
+          <View className="flex-1 items-center justify-center px-5 py-12">
+            <Feather name="cpu" size={32} color={mflColors.textMuted} />
+            <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
+            <AppText className="text-xs text-muted mt-1 text-center px-8">
+              Ask about your performance, strategy, or league standings. Everything here is private.
+            </AppText>
+          </View>
+        ) : (
+          <FlatList
+            ref={flatListRef}
+            data={messages}
+            keyExtractor={(item) => item.messageId}
+            renderItem={renderItem}
+            inverted
+            contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
       </View>
 
       {/* Sending indicator */}

--- a/src/app/(app)/(tabs)/coach.tsx
+++ b/src/app/(app)/(tabs)/coach.tsx
@@ -1,12 +1,10 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   View,
   TextInput,
-  FlatList,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
-  type ListRenderItemInfo,
 } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -27,50 +25,7 @@ import { SuggestedQuestions } from '../../../features/ai-coach/components/sugges
 import { MilestoneCard } from '../../../features/ai-coach/components/milestone-card';
 import { RecoveryCard } from '../../../features/ai-coach/components/recovery-card';
 import { WeeklyInsightCard } from '../../../features/ai-coach/components/weekly-insight-card';
-import type { AiCoachMessage } from '../../../features/ai-coach/types/ai-coach.model';
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-function formatTimestamp(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return 'Just now';
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-// ─── Message Bubble ─────────────────────────────────────────────────────────
-
-function MessageBubble({ message, isOwn }: { message: AiCoachMessage; isOwn: boolean }) {
-  if (isOwn) {
-    return (
-      <View className="items-end mb-3">
-        <View className="rounded-2xl px-4 py-3 max-w-[80%]" style={{ backgroundColor: mflColors.brand }}>
-          <AppText className="text-sm" style={{ color: '#fff' }}>{message.content}</AppText>
-        </View>
-        <AppText className="text-[10px] text-muted mt-1">{formatTimestamp(message.createdAt)}</AppText>
-      </View>
-    );
-  }
-
-  return (
-    <View className="items-start mb-3">
-      <View className="flex-row items-start gap-2 max-w-[85%]">
-        <View className="w-7 h-7 rounded-full items-center justify-center mt-1" style={{ backgroundColor: mflColors.brand }}>
-          <AppText className="text-xs font-bold" style={{ color: '#fff' }}>AI</AppText>
-        </View>
-        <View className="bg-card rounded-2xl px-4 py-3 flex-1 border border-default-200" style={{ borderLeftWidth: 3, borderLeftColor: mflColors.brand }}>
-          <AppText className="text-sm text-foreground">{message.content}</AppText>
-        </View>
-      </View>
-      <AppText className="text-[10px] text-muted mt-1 ml-9">{formatTimestamp(message.createdAt)}</AppText>
-    </View>
-  );
-}
+import { CoachChatList } from '../../../features/ai-coach/components/coach-chat-list';
 
 // ─── Insights Panel (horizontal scroll on mobile) ───────────────────────────
 
@@ -156,9 +111,6 @@ export default function CoachTab() {
   const sendMutation = useSendCoachMessage();
 
   const [input, setInput] = useState('');
-  const flatListRef = useRef<FlatList>(null);
-
-  // useCoachHistory returns newest-first for inverted FlatList.
   const messages = history ?? [];
 
   const handleSend = useCallback(
@@ -169,13 +121,6 @@ export default function CoachTab() {
       sendMutation.mutate({ leagueId, message: msg });
     },
     [input, leagueId, sendMutation],
-  );
-
-  const renderItem = useCallback(
-    ({ item }: ListRenderItemInfo<AiCoachMessage>) => (
-      <MessageBubble message={item} isOwn={item.role === 'user'} />
-    ),
-    [],
   );
 
   if (!activeLeague) {
@@ -213,28 +158,9 @@ export default function CoachTab() {
         isSending={sendMutation.isPending}
       />
 
-      {/* Chat */}
+      {/* Chat — chronological list (oldest → newest), scroll pinned to bottom */}
       <View className="flex-1">
-        {messages.length === 0 ? (
-          <View className="flex-1 items-center justify-center px-5 py-12">
-            <Feather name="cpu" size={32} color={mflColors.textMuted} />
-            <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
-            <AppText className="text-xs text-muted mt-1 text-center px-8">
-              Ask about your performance, strategy, or league standings. Everything here is private.
-            </AppText>
-          </View>
-        ) : (
-          <FlatList
-            ref={flatListRef}
-            data={messages}
-            keyExtractor={(item) => item.messageId}
-            renderItem={renderItem}
-            inverted
-            contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-          />
-        )}
+        <CoachChatList messages={messages} />
       </View>
 
       {/* Sending indicator */}

--- a/src/app/(app)/ai-coach.tsx
+++ b/src/app/(app)/ai-coach.tsx
@@ -2,13 +2,11 @@ import { useCallback, useRef, useState } from 'react';
 import {
   View,
   TextInput,
-  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
   ScrollView,
   Alert,
-  type ListRenderItemInfo,
 } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -30,62 +28,8 @@ import { SuggestedQuestions } from '../../features/ai-coach/components/suggested
 import { MilestoneCard } from '../../features/ai-coach/components/milestone-card';
 import { RecoveryCard } from '../../features/ai-coach/components/recovery-card';
 import { WeeklyInsightCard } from '../../features/ai-coach/components/weekly-insight-card';
-import type { AiCoachMessage } from '../../features/ai-coach/types/ai-coach.model';
+import { CoachChatList } from '../../features/ai-coach/components/coach-chat-list';
 import { mflColors } from '../../constants/colors';
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function formatTimestamp(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return 'Just now';
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHrs = Math.floor(diffMin / 60);
-  if (diffHrs < 24) return `${diffHrs}h ago`;
-  const diffDays = Math.floor(diffHrs / 24);
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
-
-// ─── Message Bubble ──────────────────────────────────────────────────────────
-
-function CoachBubble({ message }: { message: AiCoachMessage }) {
-  const isAssistant = message.role === 'assistant';
-
-  return (
-    <View className={`flex-row mb-3 max-w-[85%] ${isAssistant ? 'self-start' : 'self-end'}`}>
-      {isAssistant && (
-        <View
-          className="w-8 h-8 rounded-full items-center justify-center mr-2 self-end"
-          style={{ backgroundColor: '#00C48C' }}
-        >
-          <AppText className="text-white font-bold text-[11px]">AI</AppText>
-        </View>
-      )}
-      <View
-        className={`rounded-2xl px-4 py-3 max-w-full ${
-          isAssistant ? 'bg-card rounded-bl-sm border-l-[3px]' : 'rounded-br-sm'
-        }`}
-        style={isAssistant ? { borderLeftColor: '#00C48C' } : { backgroundColor: mflColors.accent }}
-      >
-        <AppText
-          className={`text-sm ${isAssistant ? 'text-foreground' : ''}`}
-          style={isAssistant ? undefined : { color: '#FFFFFF' }}
-        >
-          {message.content}
-        </AppText>
-        <AppText
-          className={`text-xs mt-1 ${isAssistant ? 'text-muted' : 'text-right'}`}
-          style={isAssistant ? undefined : { color: 'rgba(255,255,255,0.7)' }}
-        >
-          {formatTimestamp(message.createdAt)}
-        </AppText>
-      </View>
-    </View>
-  );
-}
 
 // ─── Screen ──────────────────────────────────────────────────────────────────
 
@@ -129,13 +73,6 @@ export default function AiCoachScreen() {
         Alert.alert('Error', error?.response?.data?.error || error?.message || 'Failed to get motivation.'),
     });
   }, [leagueId, motivateMutation]);
-
-  const renderMessage = useCallback(
-    ({ item }: ListRenderItemInfo<AiCoachMessage>) => <CoachBubble message={item} />,
-    [],
-  );
-
-  const keyExtractor = useCallback((item: AiCoachMessage) => item.messageId, []);
 
   if (!activeLeague) {
     return (
@@ -223,25 +160,7 @@ export default function AiCoachScreen() {
 
       {/* Chat history */}
       <View className="flex-1">
-        {(messages?.length ?? 0) === 0 ? (
-          <View className="flex-1 items-center justify-center px-4 py-12">
-            <Feather name="cpu" size={32} color={mflColors.textMuted} />
-            <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
-            <AppText className="text-xs text-muted mt-1 text-center px-8">
-              Ask about your performance, strategy, or league standings. Everything here is private.
-            </AppText>
-          </View>
-        ) : (
-          <FlatList
-            data={messages}
-            renderItem={renderMessage}
-            keyExtractor={keyExtractor}
-            inverted
-            contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 12 }}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-          />
-        )}
+        <CoachChatList messages={messages ?? []} contentPaddingHorizontal={16} />
       </View>
 
       {/* Sending indicator */}

--- a/src/app/(app)/ai-coach.tsx
+++ b/src/app/(app)/ai-coach.tsx
@@ -2,11 +2,13 @@ import { useCallback, useRef, useState } from 'react';
 import {
   View,
   TextInput,
+  FlatList,
   KeyboardAvoidingView,
   Platform,
   Pressable,
   ScrollView,
   Alert,
+  type ListRenderItemInfo,
 } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -28,8 +30,70 @@ import { SuggestedQuestions } from '../../features/ai-coach/components/suggested
 import { MilestoneCard } from '../../features/ai-coach/components/milestone-card';
 import { RecoveryCard } from '../../features/ai-coach/components/recovery-card';
 import { WeeklyInsightCard } from '../../features/ai-coach/components/weekly-insight-card';
-import { CoachChatList } from '../../features/ai-coach/components/coach-chat-list';
+import type { AiCoachMessage } from '../../features/ai-coach/types/ai-coach.model';
+import { renderCoachMarkdown } from '../../features/ai-coach/utils/render-coach-markdown';
 import { mflColors } from '../../constants/colors';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHrs = Math.floor(diffMin / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  const diffDays = Math.floor(diffHrs / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ─── Message Bubble ──────────────────────────────────────────────────────────
+
+function CoachBubble({ message }: { message: AiCoachMessage }) {
+  const isAssistant = message.role === 'assistant';
+
+  return (
+    <View className={`flex-row mb-3 max-w-[85%] ${isAssistant ? 'self-start' : 'self-end'}`}>
+      {isAssistant && (
+        <View
+          className="w-8 h-8 rounded-full items-center justify-center mr-2 self-end"
+          style={{ backgroundColor: '#00C48C' }}
+        >
+          <AppText className="text-white font-bold text-[11px]">AI</AppText>
+        </View>
+      )}
+      <View
+        className={`rounded-2xl px-4 py-3 max-w-full ${
+          isAssistant ? 'bg-card rounded-bl-sm border-l-[3px]' : 'rounded-br-sm'
+        }`}
+        style={isAssistant ? { borderLeftColor: '#00C48C' } : { backgroundColor: mflColors.accent }}
+      >
+        <AppText
+          className={`text-sm ${isAssistant ? 'text-foreground' : ''}`}
+          style={isAssistant ? undefined : { color: '#FFFFFF' }}
+        >
+          {isAssistant
+            ? renderCoachMarkdown(message.content, {
+                base: { fontSize: 14, color: mflColors.text },
+                bold: { fontWeight: '700' },
+                italic: { fontStyle: 'italic' },
+                code: { fontFamily: 'monospace', fontSize: 13 },
+              })
+            : message.content}
+        </AppText>
+        <AppText
+          className={`text-xs mt-1 ${isAssistant ? 'text-muted' : 'text-right'}`}
+          style={isAssistant ? undefined : { color: 'rgba(255,255,255,0.7)' }}
+        >
+          {formatTimestamp(message.createdAt)}
+        </AppText>
+      </View>
+    </View>
+  );
+}
 
 // ─── Screen ──────────────────────────────────────────────────────────────────
 
@@ -73,6 +137,13 @@ export default function AiCoachScreen() {
         Alert.alert('Error', error?.response?.data?.error || error?.message || 'Failed to get motivation.'),
     });
   }, [leagueId, motivateMutation]);
+
+  const renderMessage = useCallback(
+    ({ item }: ListRenderItemInfo<AiCoachMessage>) => <CoachBubble message={item} />,
+    [],
+  );
+
+  const keyExtractor = useCallback((item: AiCoachMessage) => item.messageId, []);
 
   if (!activeLeague) {
     return (
@@ -160,7 +231,25 @@ export default function AiCoachScreen() {
 
       {/* Chat history */}
       <View className="flex-1">
-        <CoachChatList messages={messages ?? []} contentPaddingHorizontal={16} />
+        {(messages?.length ?? 0) === 0 ? (
+          <View className="flex-1 items-center justify-center px-4 py-12">
+            <Feather name="cpu" size={32} color={mflColors.textMuted} />
+            <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
+            <AppText className="text-xs text-muted mt-1 text-center px-8">
+              Ask about your performance, strategy, or league standings. Everything here is private.
+            </AppText>
+          </View>
+        ) : (
+          <FlatList
+            data={messages}
+            renderItem={renderMessage}
+            keyExtractor={keyExtractor}
+            inverted
+            contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 12 }}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
       </View>
 
       {/* Sending indicator */}

--- a/src/features/ai-coach/components/coach-chat-list.tsx
+++ b/src/features/ai-coach/components/coach-chat-list.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { FlatList, View, type ListRenderItemInfo } from 'react-native';
+import Feather from '@expo/vector-icons/Feather';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { AiCoachMessage } from '../types/ai-coach.model';
+import { CoachMessageBubble } from './coach-message-bubble';
+
+interface CoachChatListProps {
+  messages: AiCoachMessage[];
+  contentPaddingHorizontal?: number;
+}
+
+export function CoachChatList({
+  messages,
+  contentPaddingHorizontal = 20,
+}: CoachChatListProps) {
+  const listRef = useRef<FlatList<AiCoachMessage>>(null);
+
+  const scrollToBottom = useCallback((animated = true) => {
+    if (messages.length === 0) return;
+    listRef.current?.scrollToEnd({ animated });
+  }, [messages.length]);
+
+  useEffect(() => {
+    scrollToBottom(false);
+  }, [messages, scrollToBottom]);
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<AiCoachMessage>) => (
+      <CoachMessageBubble message={item} />
+    ),
+    [],
+  );
+
+  if (messages.length === 0) {
+    return (
+      <View className="flex-1 items-center justify-center px-5 py-12">
+        <Feather name="cpu" size={32} color={mflColors.textMuted} />
+        <AppText className="text-sm font-medium text-muted mt-3">
+          Your Private AI Coach
+        </AppText>
+        <AppText className="text-xs text-muted mt-1 text-center px-8">
+          Ask about your performance, strategy, or league standings. Everything
+          here is private.
+        </AppText>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      ref={listRef}
+      data={messages}
+      keyExtractor={(item) => item.messageId}
+      renderItem={renderItem}
+      contentContainerStyle={{
+        paddingHorizontal: contentPaddingHorizontal,
+        paddingVertical: 12,
+      }}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      onContentSizeChange={() => scrollToBottom(true)}
+    />
+  );
+}

--- a/src/features/ai-coach/components/coach-message-bubble.tsx
+++ b/src/features/ai-coach/components/coach-message-bubble.tsx
@@ -1,0 +1,78 @@
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { AiCoachMessage } from '../types/ai-coach.model';
+import { renderCoachMarkdown } from '../utils/render-coach-markdown';
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+interface CoachMessageBubbleProps {
+  message: AiCoachMessage;
+}
+
+export function CoachMessageBubble({ message }: CoachMessageBubbleProps) {
+  const isUser = message.role === 'user';
+
+  if (isUser) {
+    return (
+      <View className="items-end mb-3">
+        <View
+          className="rounded-2xl px-4 py-3 max-w-[80%]"
+          style={{ backgroundColor: mflColors.brand }}
+        >
+          <AppText className="text-sm" style={{ color: '#fff' }}>
+            {message.content}
+          </AppText>
+        </View>
+        <AppText className="text-[10px] text-muted mt-1">
+          {formatTimestamp(message.createdAt)}
+        </AppText>
+      </View>
+    );
+  }
+
+  return (
+    <View className="items-start mb-3">
+      <View className="flex-row items-start gap-2 max-w-[85%]">
+        <View
+          className="w-7 h-7 rounded-full items-center justify-center mt-1"
+          style={{ backgroundColor: mflColors.brand }}
+        >
+          <AppText className="text-xs font-bold" style={{ color: '#fff' }}>
+            AI
+          </AppText>
+        </View>
+        <View
+          className="bg-card rounded-2xl px-4 py-3 flex-1 border border-default-200"
+          style={{ borderLeftWidth: 3, borderLeftColor: mflColors.brand }}
+        >
+          <AppText className="text-sm text-foreground">
+            {renderCoachMarkdown(message.content, {
+              base: { fontSize: 14, color: mflColors.text },
+              bold: { fontWeight: '700' },
+              italic: { fontStyle: 'italic' },
+              code: {
+                fontFamily: 'monospace',
+                fontSize: 13,
+                backgroundColor: `${mflColors.textMuted}20`,
+              },
+            })}
+          </AppText>
+        </View>
+      </View>
+      <AppText className="text-[10px] text-muted mt-1 ml-9">
+        {formatTimestamp(message.createdAt)}
+      </AppText>
+    </View>
+  );
+}

--- a/src/features/ai-coach/hooks/use-coach-history.ts
+++ b/src/features/ai-coach/hooks/use-coach-history.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../../../core/config';
 import { fetchChatHistory } from '../services/ai-coach.service';
 import { toAiCoachMessage } from '../mappers/ai-coach.mapper';
-import { sortCoachMessages } from '../utils/sort-coach-messages';
 import type { AiCoachMessage } from '../types/ai-coach.model';
 
 export function useCoachHistory(leagueId: string) {
@@ -10,8 +9,17 @@ export function useCoachHistory(leagueId: string) {
     queryKey: queryKeys.leagues.aiCoachHistory(leagueId),
     queryFn: async () => {
       const dto = await fetchChatHistory(leagueId);
-      const messages = dto.messages.map(toAiCoachMessage);
-      return sortCoachMessages(messages);
+      // API ascending; bulk insert can share created_at — keep user before assistant.
+      return dto.messages
+        .map(toAiCoachMessage)
+        .sort((a, b) => {
+          const t =
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          if (t !== 0) return t;
+          if (a.role === b.role) return 0;
+          return a.role === 'user' ? -1 : 1;
+        })
+        .reverse();
     },
     enabled: !!leagueId,
     staleTime: 60 * 1000,

--- a/src/features/ai-coach/hooks/use-coach-history.ts
+++ b/src/features/ai-coach/hooks/use-coach-history.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../../../core/config';
 import { fetchChatHistory } from '../services/ai-coach.service';
 import { toAiCoachMessage } from '../mappers/ai-coach.mapper';
+import { sortCoachMessages } from '../utils/sort-coach-messages';
 import type { AiCoachMessage } from '../types/ai-coach.model';
 
 export function useCoachHistory(leagueId: string) {
@@ -9,11 +10,10 @@ export function useCoachHistory(leagueId: string) {
     queryKey: queryKeys.leagues.aiCoachHistory(leagueId),
     queryFn: async () => {
       const dto = await fetchChatHistory(leagueId);
-      // Reverse: API returns ascending (oldest first), but inverted FlatList
-      // needs descending (newest first) so newest appears at screen bottom.
-      return dto.messages.map(toAiCoachMessage).reverse();
+      const messages = dto.messages.map(toAiCoachMessage);
+      return sortCoachMessages(messages);
     },
     enabled: !!leagueId,
-    staleTime: 60 * 1000, // 1 minute
+    staleTime: 60 * 1000,
   });
 }

--- a/src/features/ai-coach/hooks/use-send-coach-message.ts
+++ b/src/features/ai-coach/hooks/use-send-coach-message.ts
@@ -2,21 +2,64 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '../../../core/config';
 import { sendCoachMessage } from '../services/ai-coach.service';
 import type { AiCoachResponseDTO } from '../types/ai-coach.dto';
+import type { AiCoachMessage } from '../types/ai-coach.model';
+import { sortCoachMessages } from '../utils/sort-coach-messages';
 
 interface SendCoachMessageVars {
   leagueId: string;
   message: string;
 }
 
+interface SendCoachMessageContext {
+  previous?: AiCoachMessage[];
+}
+
+function createOptimisticUserMessage(content: string): AiCoachMessage {
+  return {
+    messageId: `optimistic-user-${Date.now()}`,
+    role: 'user',
+    content,
+    createdAt: new Date().toISOString(),
+  };
+}
+
 export function useSendCoachMessage() {
   const queryClient = useQueryClient();
 
-  return useMutation<AiCoachResponseDTO, Error, SendCoachMessageVars>({
+  return useMutation<
+    AiCoachResponseDTO,
+    Error,
+    SendCoachMessageVars,
+    SendCoachMessageContext
+  >({
     mutationFn: async ({ leagueId, message }) => {
       return sendCoachMessage(leagueId, message);
     },
-    onSuccess: (_data, { leagueId }) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.leagues.aiCoachHistory(leagueId) });
+    onMutate: async ({ leagueId, message }) => {
+      const historyKey = queryKeys.leagues.aiCoachHistory(leagueId);
+      await queryClient.cancelQueries({ queryKey: historyKey });
+
+      const previous = queryClient.getQueryData<AiCoachMessage[]>(historyKey);
+      const optimisticUser = createOptimisticUserMessage(message);
+
+      queryClient.setQueryData<AiCoachMessage[]>(historyKey, (current) =>
+        sortCoachMessages([...(current ?? []), optimisticUser]),
+      );
+
+      return { previous };
+    },
+    onError: (_error, { leagueId }, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(
+          queryKeys.leagues.aiCoachHistory(leagueId),
+          context.previous,
+        );
+      }
+    },
+    onSettled: (_data, _error, { leagueId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.leagues.aiCoachHistory(leagueId),
+      });
     },
   });
 }

--- a/src/features/ai-coach/utils/render-coach-markdown.tsx
+++ b/src/features/ai-coach/utils/render-coach-markdown.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from 'react';
+import { Text, type TextStyle } from 'react-native';
+
+type MarkdownStyle = {
+  base: TextStyle;
+  bold: TextStyle;
+  italic: TextStyle;
+  code: TextStyle;
+};
+
+function parseInlineMarkdown(
+  text: string,
+  style: MarkdownStyle,
+): ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let index = 0;
+  let key = 0;
+
+  while (index < text.length) {
+    if (text.startsWith('**', index)) {
+      const end = text.indexOf('**', index + 2);
+      if (end !== -1) {
+        const inner = text.slice(index + 2, end);
+        nodes.push(
+          <Text key={key++} style={style.bold}>
+            {parseInlineMarkdown(inner, style)}
+          </Text>,
+        );
+        index = end + 2;
+        continue;
+      }
+    }
+
+    if (text[index] === '*' && !text.startsWith('**', index)) {
+      const end = text.indexOf('*', index + 1);
+      if (end !== -1) {
+        const inner = text.slice(index + 1, end);
+        nodes.push(
+          <Text key={key++} style={style.italic}>
+            {parseInlineMarkdown(inner, style)}
+          </Text>,
+        );
+        index = end + 1;
+        continue;
+      }
+    }
+
+    if (text[index] === '`') {
+      const end = text.indexOf('`', index + 1);
+      if (end !== -1) {
+        nodes.push(
+          <Text key={key++} style={style.code}>
+            {text.slice(index + 1, end)}
+          </Text>,
+        );
+        index = end + 1;
+        continue;
+      }
+    }
+
+    let next = text.length;
+    const nextBold = text.indexOf('**', index);
+    const nextItalic = text.indexOf('*', index);
+    const nextCode = text.indexOf('`', index);
+    if (nextBold !== -1 && nextBold < next) next = nextBold;
+    if (nextItalic !== -1 && nextItalic < next) next = nextItalic;
+    if (nextCode !== -1 && nextCode < next) next = nextCode;
+
+    nodes.push(text.slice(index, next));
+    index = next;
+  }
+
+  return nodes;
+}
+
+export function renderCoachMarkdown(
+  text: string,
+  style: MarkdownStyle,
+): ReactNode {
+  const lines = text.split('\n');
+
+  return lines.map((line, lineIndex) => (
+    <Text key={`line-${lineIndex}`}>
+      {parseInlineMarkdown(line, style)}
+      {lineIndex < lines.length - 1 ? '\n' : null}
+    </Text>
+  ));
+}

--- a/src/features/ai-coach/utils/render-coach-markdown.tsx
+++ b/src/features/ai-coach/utils/render-coach-markdown.tsx
@@ -1,88 +1,61 @@
 import type { ReactNode } from 'react';
 import { Text, type TextStyle } from 'react-native';
 
-type MarkdownStyle = {
-  base: TextStyle;
-  bold: TextStyle;
-  italic: TextStyle;
-  code: TextStyle;
-};
-
-function parseInlineMarkdown(
-  text: string,
-  style: MarkdownStyle,
-): ReactNode[] {
-  const nodes: React.ReactNode[] = [];
-  let index = 0;
-  let key = 0;
-
-  while (index < text.length) {
-    if (text.startsWith('**', index)) {
-      const end = text.indexOf('**', index + 2);
-      if (end !== -1) {
-        const inner = text.slice(index + 2, end);
-        nodes.push(
-          <Text key={key++} style={style.bold}>
-            {parseInlineMarkdown(inner, style)}
-          </Text>,
-        );
-        index = end + 2;
-        continue;
-      }
-    }
-
-    if (text[index] === '*' && !text.startsWith('**', index)) {
-      const end = text.indexOf('*', index + 1);
-      if (end !== -1) {
-        const inner = text.slice(index + 1, end);
-        nodes.push(
-          <Text key={key++} style={style.italic}>
-            {parseInlineMarkdown(inner, style)}
-          </Text>,
-        );
-        index = end + 1;
-        continue;
-      }
-    }
-
-    if (text[index] === '`') {
-      const end = text.indexOf('`', index + 1);
-      if (end !== -1) {
-        nodes.push(
-          <Text key={key++} style={style.code}>
-            {text.slice(index + 1, end)}
-          </Text>,
-        );
-        index = end + 1;
-        continue;
-      }
-    }
-
-    let next = text.length;
-    const nextBold = text.indexOf('**', index);
-    const nextItalic = text.indexOf('*', index);
-    const nextCode = text.indexOf('`', index);
-    if (nextBold !== -1 && nextBold < next) next = nextBold;
-    if (nextItalic !== -1 && nextItalic < next) next = nextItalic;
-    if (nextCode !== -1 && nextCode < next) next = nextCode;
-
-    nodes.push(text.slice(index, next));
-    index = next;
-  }
-
-  return nodes;
-}
-
+/** Minimal **bold** / *italic* / `code` for assistant replies (no new dependency). */
 export function renderCoachMarkdown(
   text: string,
-  style: MarkdownStyle,
+  style: { base: TextStyle; bold: TextStyle; italic: TextStyle; code: TextStyle },
 ): ReactNode {
-  const lines = text.split('\n');
-
-  return lines.map((line, lineIndex) => (
-    <Text key={`line-${lineIndex}`}>
-      {parseInlineMarkdown(line, style)}
+  return text.split('\n').map((line, lineIndex, lines) => (
+    <Text key={`l-${lineIndex}`}>
+      {parseInline(line, style, `l-${lineIndex}`)}
       {lineIndex < lines.length - 1 ? '\n' : null}
     </Text>
   ));
+}
+
+function parseInline(
+  text: string,
+  style: { base: TextStyle; bold: TextStyle; italic: TextStyle; code: TextStyle },
+  keyPrefix: string,
+): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let i = 0;
+  let k = 0;
+
+  while (i < text.length) {
+    if (text.startsWith('**', i)) {
+      const end = text.indexOf('**', i + 2);
+      if (end !== -1) {
+        nodes.push(
+          <Text key={`${keyPrefix}-b-${k++}`} style={style.bold}>
+            {parseInline(text.slice(i + 2, end), style, `${keyPrefix}-b-${k}`)}
+          </Text>,
+        );
+        i = end + 2;
+        continue;
+      }
+    }
+    if (text[i] === '`') {
+      const end = text.indexOf('`', i + 1);
+      if (end !== -1) {
+        nodes.push(
+          <Text key={`${keyPrefix}-c-${k++}`} style={style.code}>
+            {text.slice(i + 1, end)}
+          </Text>,
+        );
+        i = end + 1;
+        continue;
+      }
+    }
+    let next = text.length;
+    for (const marker of ['**', '`']) {
+      const at = text.indexOf(marker, i);
+      if (at !== -1 && at < next) next = at;
+    }
+    nodes.push(text.slice(i, next));
+    i = next;
+  }
+
+  return nodes;
 }

--- a/src/features/ai-coach/utils/sort-coach-messages.ts
+++ b/src/features/ai-coach/utils/sort-coach-messages.ts
@@ -1,0 +1,13 @@
+import type { AiCoachMessage } from '../types/ai-coach.model';
+
+/** Chronological order for chat UI (oldest → newest). */
+export function sortCoachMessages(messages: AiCoachMessage[]): AiCoachMessage[] {
+  return [...messages].sort((a, b) => {
+    const timeDiff =
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (timeDiff !== 0) return timeDiff;
+    // Same timestamp (bulk insert): user question before assistant reply.
+    if (a.role === b.role) return 0;
+    return a.role === 'user' ? -1 : 1;
+  });
+}


### PR DESCRIPTION
## Summary

Fix AI coach message ordering and markdown rendering — user message always above assistant reply, bold and code formatting works.

## What was broken

1. **Message order** — user and assistant rows inserted with same `created_at`. API returned unstable order, so after `.reverse()` for inverted list, assistant could appear above user question.

2. **Raw markdown** — assistant text with `**bold**` and `` `code` `` was rendered as plain text, not formatted.

## What was fixed

| File | Change |
|------|--------|
| `use-coach-history.ts` | Sort ascending with user before assistant on tie, then `.reverse()` |
| `render-coach-markdown.tsx` | Lightweight `**bold**` / `` `code` `` renderer |
| `coach.tsx` | Use markdown renderer for AI bubbles only |
| `ai-coach.tsx` | Same |

## Impact

- **Mobile** — AI Coach tab and AI Coach screen

## Risk

- Low — sort is stable tiebreaker only, renderer is additive, no optimistic changes

## Files Modified

- `src/features/ai-coach/hooks/use-coach-history.ts`
- `src/features/ai-coach/utils/render-coach-markdown.tsx`
- `src/app/(app)/(tabs)/coach.tsx`
- `src/app/(app)/ai-coach.tsx`