### PR TITLE
fix: hide inline proof images from activity list cards, show tap for …

### DIFF
--- a/src/app/(app)/(tabs)/my-activity.tsx
+++ b/src/app/(app)/(tabs)/my-activity.tsx
@@ -1,7 +1,7 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useRouter } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
-import { View, Pressable, Image } from 'react-native';
+import { View, Pressable } from 'react-native';
 import { Button, Card, Chip, Separator, Tabs } from 'heroui-native';
 
 import { AppText } from '../../../components/app-text';
@@ -190,9 +190,10 @@ function SubmissionCard({
           </Chip>
         </View>
 
-        {/* Date */}
+        {/* Date + duration summary */}
         <AppText className="text-xs text-muted mt-1">
           {formatDate(entry.date)}
+          {entry.duration != null ? ` · ${entry.duration} min` : ''}
         </AppText>
 
         {/* Reupload indicator */}
@@ -246,23 +247,10 @@ function SubmissionCard({
           )}
         </View>
 
-        {/* Proof thumbnail */}
         {entry.proofUrl && (
-          <View className="mt-2 rounded-lg overflow-hidden" style={{ height: 120 }}>
-            <Image
-              source={{ uri: entry.proofUrl }}
-              style={{ width: '100%', height: '100%' }}
-              resizeMode="cover"
-            />
-          </View>
-        )}
-
-        {/* Notes */}
-        {entry.notes && !isExemption && (
-          <View className="mt-2 p-2 rounded-lg" style={{ backgroundColor: mflColors.surface }}>
-            <AppText className="text-xs text-muted" numberOfLines={2}>
-              {entry.notes}
-            </AppText>
+          <View className="flex-row items-center gap-1 mt-2">
+            <Feather name="image" size={12} color={mflColors.textMuted} />
+            <AppText className="text-[10px] text-muted">Proof attached — tap for details</AppText>
           </View>
         )}
 

--- a/src/features/validation/components/submission-validation-card.tsx
+++ b/src/features/validation/components/submission-validation-card.tsx
@@ -1,5 +1,5 @@
 import Feather from '@expo/vector-icons/Feather';
-import { Image, Pressable, TextInput, View } from 'react-native';
+import { TextInput, View } from 'react-native';
 import { Avatar, Button, Card, Spinner } from 'heroui-native';
 
 import { AppText } from '../../../components/app-text';
@@ -129,13 +129,7 @@ export function SubmissionValidationCard({
       ) : null}
 
       {submission.proofUrl ? (
-        <Pressable onPress={() => onView(submission)} className="rounded-xl overflow-hidden">
-          <Image
-            source={{ uri: submission.proofUrl }}
-            style={{ width: '100%', height: 150, borderRadius: 12 }}
-            resizeMode="cover"
-          />
-        </Pressable>
+        <AppText className="text-xs text-muted">Proof attached — tap View for full details</AppText>
       ) : null}
 
       {submission.plausibilityScore != null && submission.plausibilityScore < 50 ? (
@@ -149,15 +143,6 @@ export function SubmissionValidationCard({
             {submission.reviewTier && submission.reviewTier !== 'none'
               ? ` · Flagged for ${submission.reviewTier}`
               : ''}
-          </AppText>
-        </View>
-      ) : null}
-
-      {submission.notes ? (
-        <View className="rounded-xl p-3 bg-default-100">
-          <AppText className="text-[10px] font-semibold text-muted uppercase">Notes</AppText>
-          <AppText className="text-xs text-foreground mt-1" numberOfLines={2}>
-            {submission.notes}
           </AppText>
         </View>
       ) : null}


### PR DESCRIPTION
## Summary

Hide inline proof images and notes from My Activity and Team Activities list cards. Full proof still visible on tap.

## What was broken

My Activity and Team Activities list views showed large inline proof thumbnails and notes preview, cluttering the list and making it hard to scan submissions.

## What was fixed

| File | Change |
|------|--------|
| `my-activity.tsx` | Removed inline `Image` and notes from list card. Shows "Proof attached — tap for details" hint. Tap opens full `submission-detail`. |
| `submission-validation-card.tsx` | Removed inline proof image and notes preview. Shows "Proof attached — tap View for full details". **View** opens `SubmissionDetailPanel`. |

List cards now show: type, date, duration, points, metrics only.

## Tested

- My Activity list — no inline proof image, "Proof attached" hint visible
- Tap card — opens full submission detail with proof
- Team Activities list — no inline proof, "View" opens full panel
- Challenge review panel unchanged (separate flow)

## Impact

- **Mobile** — My Activity and Team Activities list views

## Risk

- Low — only removes inline display, tap-to-view-full-detail unchanged

## Files Modified

- `src/app/(app)/(tabs)/my-activity.tsx`
- `src/features/validation/components/submission-validation-card.tsx`