### PR TITLE
fix(navigation): auto-navigate to league overview when user has singl…

### DIFF
--- a/src/app/(app)/(tabs)/dashboard.tsx
+++ b/src/app/(app)/(tabs)/dashboard.tsx
@@ -1,7 +1,7 @@
 import Feather from '@expo/vector-icons/Feather';
 import { StatusBar } from 'expo-status-bar';
 import { useRouter } from 'expo-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable } from 'react-native';
 import { Button, Card, Chip } from 'heroui-native';
 
@@ -92,6 +92,20 @@ export default function DashboardScreen() {
     () => buildStreakDays(summary?.currentStreak ?? 0),
     [summary?.currentStreak],
   );
+
+  // Auto-navigate when user has exactly one active league — skip manual selection
+  const hasAutoNavigated = useRef(false);
+  useEffect(() => {
+    if (
+      hasAutoNavigated.current ||
+      leaguesQuery.isLoading ||
+      visibleLeagues.length !== 1
+    ) return;
+    hasAutoNavigated.current = true;
+    const only = visibleLeagues[0]!;
+    setActiveLeague(only);
+    router.replace('/(app)/league-overview' as any);
+  }, [leaguesQuery.isLoading, visibleLeagues, setActiveLeague, router]);
 
   // ── Loading state ──────────────────────────────────────────────────────
   if (dashboardQuery.isLoading) {
@@ -203,7 +217,7 @@ export default function DashboardScreen() {
                     league={league}
                     onPress={() => {
                       setActiveLeague(league);
-                      router.push(`/(app)/league-detail` as any);
+                      router.push(`/(app)/league-overview` as any);
                     }}
                   />
                 </View>


### PR DESCRIPTION
## Summary
Auto-navigate to league overview when user has exactly one active league — skip manual league selection on dashboard.

## What was broken
Users with a single active league had to manually tap the league card on the dashboard to enter it. AR Sir's feedback required that if a user has only one active league, the app should navigate directly to that league's dashboard without an extra tap.

Also fixed: league card tap was navigating to `/(app)/league-detail` which doesn't exist — replaced with `/(app)/league-overview`.

## What was fixed
- Added `useEffect` that checks if user has exactly one active league after leagues load
- If true, sets it as active league and navigates directly to `league-overview` via `router.replace`
- `hasAutoNavigated` ref prevents infinite re-navigation loop
- `router.replace` used instead of `push` so back button doesn't loop back to dashboard
- League card tap also updated to correct route `league-overview`

## Tested
- Single league user → auto-navigates to league overview on login
- Multiple league user → stays on dashboard for manual selection
- Back button does not loop

## Impact
Mobile — dashboard navigation flow

## Risk
Low — additive change, existing multi-league flow unchanged

## Files Modified
- `src/app/(app)/(tabs)/dashboard.tsx`