### PR TITLE
fix: remove duplicate leaderboard heading and handle tiebreaker info

### DIFF
--- a/src/features/leaderboard/components/leaderboard-screen.tsx
+++ b/src/features/leaderboard/components/leaderboard-screen.tsx
@@ -172,9 +172,6 @@ export function LeaderboardScreen() {
         <Animated.View entering={FadeInDown.duration(250)} className="gap-3">
           <View className="flex-row items-start justify-between gap-3">
             <View className="flex-1">
-              <AppText className="text-2xl font-bold text-foreground">
-                Leaderboard
-              </AppText>
               <AppText className="mt-1 text-sm text-muted" numberOfLines={1}>
                 {league?.league_name || activeLeague.name || 'Rankings'}
               </AppText>

--- a/src/features/leaderboard/components/tiebreaker-info.tsx
+++ b/src/features/leaderboard/components/tiebreaker-info.tsx
@@ -1,26 +1,33 @@
 import Feather from '@expo/vector-icons/Feather';
-import { View } from 'react-native';
+import { Alert, Pressable, View } from 'react-native';
 import { AppText } from '../../../components/app-text';
 import { mflColors } from '../../../constants/colors';
 
 export function TiebreakerInfo() {
+  const handlePress = () => {
+    Alert.alert(
+      'Tiebreaker',
+      'Teams with higher Avg Run Rate (RR) rank higher when points are equal.',
+    );
+  };
+
   return (
     <View className="mt-4 flex-row items-start gap-2 px-1">
-      <View
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Show tiebreaker rule"
+        hitSlop={10}
+        onPress={handlePress}
         className="h-5 w-5 items-center justify-center rounded-full"
         style={{ backgroundColor: mflColors.surface, borderWidth: 1, borderColor: mflColors.inkLight }}
       >
         <Feather name="info" size={10} color={mflColors.textMuted} />
-      </View>
+      </Pressable>
       <View className="flex-1">
         <AppText className="text-xs text-muted">
           <AppText className="text-xs font-bold text-foreground">
-            Tiebreaker:
+            Tiebreaker
           </AppText>
-          {' '}Teams with higher Avg Run Rate (RR) rank higher.
-        </AppText>
-        <AppText className="mt-1 text-[10px] text-muted">
-          When points are equal, higher RR rewards consistency and effort intensity.
         </AppText>
       </View>
     </View>


### PR DESCRIPTION
## Summary
Fixes two leaderboard UI issues on mobile:
- Removed the duplicate "Leaderboard" heading.
- Fixed the non-functional tiebreaker info button.

## Related Issue
Closes #41 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [x] UI/UX improvement
- [ ] Chore (dependencies, config, CI)
- [ ] Documentation

## Changes Made
- Removed the redundant in-page "Leaderboard" heading.
- Added functionality to the tiebreaker info button.
- Kept existing leaderboard behavior unchanged.

## How to Test
1. Open the mobile app.
2. Navigate to the Leaderboard screen.
3. Verify that only one "Leaderboard" heading is displayed.
4. Tap the tiebreaker info icon.
5. Verify that the expected tiebreaker information is shown.
6. Confirm leaderboard rankings and navigation continue to work as expected.


## Checklist
- [x] I have tested this locally and it works
- [x] No console.log or commented-out code left behind
- [x] My branch is up to date with develop
- [x] I have not modified any files outside the scope of this task