### PR TITLE
fix: update drawer nav labels and ordering to match web sidebar

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -57,13 +57,14 @@ function getDrawerNavSections(
     sections.push({
       title: '',
       items: [
-        { label: 'Overview', icon: 'grid', route: '(tabs)/dashboard' },
-        { label: 'My Challenges', icon: 'flag', route: 'challenges' },
+        { label: 'My Zone', icon: 'grid', route: '(tabs)/dashboard' },
+        { label: 'Challenges', icon: 'flag', route: 'challenges' },
         { label: 'My Team', icon: 'users', route: '(tabs)/my-team' },
         { label: 'Team Chat', icon: 'message-circle', route: '(tabs)/team-chat' },
+        { label: 'AI Coach', icon: 'cpu', route: 'ai-coach' },
+        { label: 'Wearables', icon: 'watch', route: 'wearables' },
         { label: 'Leaderboard', icon: 'bar-chart-2', route: '(tabs)/leaderboard' },
         { label: 'Rules', icon: 'book-open', route: 'league-rules' },
-        { label: 'Wearables', icon: 'watch', route: 'wearables' },
       ],
     });
   }


### PR DESCRIPTION
fix: update drawer nav labels and ordering to match web sidebar

## Summary
Aligns the mobile drawer navigation labels and ordering with the web sidebar for the player/captain/vice-captain role.

## What changed

| Before | After |
|---|---|
| Overview | **My Zone** |
| My Challenges | **Challenges** |
| My Team | My Team |
| Team Chat | Team Chat |
| *(missing)* | **AI Coach** ← added |
| Leaderboard | Wearables ← moved up |
| Rules | Leaderboard |
| Wearables | Rules |

Final order: `My Zone → Challenges → My Team → Team Chat → AI Coach → Wearables → Leaderboard → Rules`

## Files Modified
- `src/app/(app)/_layout.tsx`

## Testing
- Open drawer as player — verify new labels and order

## Impact
Mobile app — drawer navigation only. No logic changes.

## Risk
Low — label and order changes only. No routing or logic modified.