### PR TITLE
Feat/phase2 mobile parity

### DIFF
--- a/src/app/(app)/(tabs)/coach.tsx
+++ b/src/app/(app)/(tabs)/coach.tsx
@@ -1,283 +1,76 @@
-import { useCallback, useRef, useState } from 'react';
-import {
-  View,
-  TextInput,
-  FlatList,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  type ListRenderItemInfo,
-} from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
+import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, Spinner } from 'heroui-native';
 import { AppText } from '../../../components/app-text';
-import { DarkHeaderCard } from '../../../components/dark-header-card';
-import { ScreenState } from '../../../components/screen-state';
+import { ScreenScrollView } from '../../../components/screen-scroll-view';
 import { mflColors } from '../../../constants/colors';
-import { useLeagueContext } from '../../../contexts/league-context';
-import { useCoachHistory } from '../../../features/ai-coach/hooks/use-coach-history';
-import { useSendCoachMessage } from '../../../features/ai-coach/hooks/use-send-coach-message';
-import { useSuggestedQuestions } from '../../../features/ai-coach/hooks/use-suggested-questions';
-import { useMilestones } from '../../../features/ai-coach/hooks/use-milestones';
-import { useRecovery } from '../../../features/ai-coach/hooks/use-recovery';
-import { useWeeklyInsight, useGenerateWeeklyInsight } from '../../../features/ai-coach/hooks/use-weekly-insight';
-import { useDismissMilestone } from '../../../features/ai-coach/hooks/use-dismiss-milestone';
-import { SuggestedQuestions } from '../../../features/ai-coach/components/suggested-questions';
-import { MilestoneCard } from '../../../features/ai-coach/components/milestone-card';
-import { RecoveryCard } from '../../../features/ai-coach/components/recovery-card';
-import { WeeklyInsightCard } from '../../../features/ai-coach/components/weekly-insight-card';
-import type { AiCoachMessage } from '../../../features/ai-coach/types/ai-coach.model';
-import { renderCoachMarkdown } from '../../../features/ai-coach/utils/render-coach-markdown';
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-function formatTimestamp(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return 'Just now';
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-// ─── Message Bubble ─────────────────────────────────────────────────────────
-
-function MessageBubble({ message, isOwn }: { message: AiCoachMessage; isOwn: boolean }) {
-  if (isOwn) {
-    return (
-      <View className="items-end mb-3">
-        <View className="rounded-2xl px-4 py-3 max-w-[80%]" style={{ backgroundColor: mflColors.brand }}>
-          <AppText className="text-sm" style={{ color: '#fff' }}>{message.content}</AppText>
-        </View>
-        <AppText className="text-[10px] text-muted mt-1">{formatTimestamp(message.createdAt)}</AppText>
-      </View>
-    );
-  }
-
-  return (
-    <View className="items-start mb-3">
-      <View className="flex-row items-start gap-2 max-w-[85%]">
-        <View className="w-7 h-7 rounded-full items-center justify-center mt-1" style={{ backgroundColor: mflColors.brand }}>
-          <AppText className="text-xs font-bold" style={{ color: '#fff' }}>AI</AppText>
-        </View>
-        <View className="bg-card rounded-2xl px-4 py-3 flex-1 border border-default-200" style={{ borderLeftWidth: 3, borderLeftColor: mflColors.brand }}>
-          <AppText className="text-sm text-foreground">
-            {renderCoachMarkdown(message.content, {
-              base: { fontSize: 14, color: mflColors.text },
-              bold: { fontWeight: '700' },
-              italic: { fontStyle: 'italic' },
-              code: { fontFamily: 'monospace', fontSize: 13 },
-            })}
-          </AppText>
-        </View>
-      </View>
-      <AppText className="text-[10px] text-muted mt-1 ml-9">{formatTimestamp(message.createdAt)}</AppText>
-    </View>
-  );
-}
-
-// ─── Insights Panel (horizontal scroll on mobile) ───────────────────────────
-
-function InsightsPanel({
-  leagueId,
-  onSelectQuestion,
-  isSending,
-}: {
-  leagueId: string;
-  onSelectQuestion: (text: string) => void;
-  isSending: boolean;
-}) {
-  const { data: suggestions } = useSuggestedQuestions(leagueId);
-  const { data: milestones } = useMilestones(leagueId);
-  const { data: recovery } = useRecovery(leagueId);
-  const { data: weeklyInsight } = useWeeklyInsight(leagueId);
-  const generateInsight = useGenerateWeeklyInsight();
-  const dismissMilestone = useDismissMilestone();
-
-  const hasContent =
-    (suggestions && suggestions.length > 0) ||
-    (milestones && milestones.length > 0) ||
-    (recovery && recovery.needsRecovery) ||
-    weeklyInsight !== undefined;
-
-  if (!hasContent) return null;
-
-  return (
-    <ScrollView
-      horizontal={false}
-      className="max-h-52 border-b border-default-200"
-      contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8 }}
-      showsVerticalScrollIndicator={false}
-    >
-      {/* Suggested Questions */}
-      {suggestions && suggestions.length > 0 && (
-        <SuggestedQuestions
-          questions={suggestions}
-          onSelect={onSelectQuestion}
-          disabled={isSending}
-        />
-      )}
-
-      {/* Recovery */}
-      {recovery && <RecoveryCard recovery={recovery} />}
-
-      {/* Milestones */}
-      {milestones && milestones.length > 0 && (
-        <View className="mb-1">
-          <AppText className="text-xs font-medium text-muted mb-1.5 px-4">Milestones</AppText>
-          <View className="px-4">
-            {milestones.slice(0, 3).map((m) => (
-              <MilestoneCard
-                key={m.id}
-                milestone={m}
-                onDismiss={(id) => dismissMilestone.mutate({ leagueId, messageId: id })}
-              />
-            ))}
-          </View>
-        </View>
-      )}
-
-      {/* Weekly Insight */}
-      <View className="px-4">
-        <WeeklyInsightCard
-          insight={weeklyInsight ?? null}
-          isGenerating={generateInsight.isPending}
-          onGenerate={() => generateInsight.mutate(leagueId)}
-        />
-      </View>
-    </ScrollView>
-  );
-}
-
-// ─── Screen ─────────────────────────────────────────────────────────────────
-
+/**
+ * AI Coach — Coming Soon
+ *
+ * The AI Coach feature is under active development. This placeholder screen
+ * replaces the previous functional screen per Phase 2 UI review (09 Jun 2026).
+ * The tab remains accessible but non-functional until the feature is ready.
+ */
 export default function CoachTab() {
   const insets = useSafeAreaInsets();
-  const { activeLeague } = useLeagueContext();
-  const leagueId = activeLeague?.leagueId ?? '';
-
-  const { data: history, isLoading, isError, refetch } = useCoachHistory(leagueId);
-  const sendMutation = useSendCoachMessage();
-
-  const [input, setInput] = useState('');
-  const flatListRef = useRef<FlatList>(null);
-
-  // useCoachHistory returns newest-first for inverted FlatList.
-  const messages = history ?? [];
-
-  const handleSend = useCallback(
-    (text?: string) => {
-      const msg = (text ?? input).trim();
-      if (!msg || !leagueId) return;
-      setInput('');
-      sendMutation.mutate({ leagueId, message: msg });
-    },
-    [input, leagueId, sendMutation],
-  );
-
-  const renderItem = useCallback(
-    ({ item }: ListRenderItemInfo<AiCoachMessage>) => (
-      <MessageBubble message={item} isOwn={item.role === 'user'} />
-    ),
-    [],
-  );
-
-  if (!activeLeague) {
-    return <ScreenState screen="coach" state="empty" message="Select a league to chat with your AI coach" />;
-  }
-
-  if (isLoading) {
-    return <ScreenState screen="coach" state="loading" message="Loading coach..." />;
-  }
-
-  if (isError) {
-    return <ScreenState screen="coach" state="error" actionLabel="Retry" onAction={() => refetch()} />;
-  }
 
   return (
-    <KeyboardAvoidingView
-      className="flex-1 bg-background"
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={insets.top + 56}
-    >
-      {/* Header */}
-      <View className="px-5" style={{ paddingTop: insets.top + 8 }}>
-        <DarkHeaderCard title="AI Coach" subtitle="Powered by AI" />
-        {/* Privacy indicator */}
-        <View className="flex-row items-center gap-1 mt-1 self-end">
-          <Feather name="lock" size={10} color={mflColors.textMuted} />
-          <AppText className="text-[10px] text-muted">Private to you</AppText>
+    <ScreenScrollView>
+      <View
+        className="flex-1 items-center justify-center px-8"
+        style={{ paddingTop: insets.top + 48, paddingBottom: 48, gap: 24 }}
+      >
+        {/* Icon */}
+        <View
+          className="w-20 h-20 rounded-2xl items-center justify-center"
+          style={{ backgroundColor: mflColors.brandLight }}
+        >
+          <Feather name="cpu" size={36} color={mflColors.brand} />
         </View>
-      </View>
 
-      {/* Insights Panel — suggested questions, milestones, recovery, weekly insight */}
-      <InsightsPanel
-        leagueId={leagueId}
-        onSelectQuestion={handleSend}
-        isSending={sendMutation.isPending}
-      />
-
-      {/* Chat */}
-      <View className="flex-1">
-        {messages.length === 0 ? (
-          <View className="flex-1 items-center justify-center px-5 py-12">
-            <Feather name="cpu" size={32} color={mflColors.textMuted} />
-            <AppText className="text-sm font-medium text-muted mt-3">Your Private AI Coach</AppText>
-            <AppText className="text-xs text-muted mt-1 text-center px-8">
-              Ask about your performance, strategy, or league standings. Everything here is private.
+        {/* Title */}
+        <View className="items-center gap-2">
+          <AppText className="text-2xl font-bold text-foreground text-center">
+            AI Coach
+          </AppText>
+          <View
+            className="flex-row items-center gap-2 rounded-full px-4 py-1.5"
+            style={{ backgroundColor: mflColors.amberLight }}
+          >
+            <Feather name="clock" size={13} color={mflColors.amber} />
+            <AppText className="text-xs font-semibold" style={{ color: mflColors.amber }}>
+              Coming Soon
             </AppText>
           </View>
-        ) : (
-          <FlatList
-            ref={flatListRef}
-            data={messages}
-            keyExtractor={(item) => item.messageId}
-            renderItem={renderItem}
-            inverted
-            contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 8 }}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-          />
-        )}
-      </View>
-
-      {/* Sending indicator */}
-      {sendMutation.isPending && (
-        <View className="px-5 pb-1 flex-row items-center gap-2">
-          <Spinner size="sm" />
-          <AppText className="text-xs text-muted">Coach is thinking...</AppText>
         </View>
-      )}
 
-      {/* Input */}
-      <View className="flex-row items-end gap-2 px-5 py-3 bg-card border-t border-default-200" style={{ paddingBottom: Math.max(insets.bottom, 8) }}>
-        <TextInput
-          className="flex-1 bg-background rounded-2xl px-4 py-3 text-sm text-foreground border border-default-200"
-          placeholder="Ask your coach..."
-          placeholderTextColor={mflColors.textMuted}
-          value={input}
-          onChangeText={setInput}
-          multiline
-          maxLength={500}
-          onSubmitEditing={() => handleSend()}
-          blurOnSubmit={false}
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          onPress={() => handleSend()}
-          isDisabled={!input.trim() || sendMutation.isPending}
-        >
-          {sendMutation.isPending ? <Spinner size="sm" /> : <Button.Label>Send</Button.Label>}
-        </Button>
+        {/* Description */}
+        <AppText className="text-sm text-muted text-center leading-6 max-w-xs">
+          Your personalised AI Coach will analyse your activity patterns,
+          league standings, and motivation profile to give you daily nudges,
+          insights, and recommendations — built just for you.
+        </AppText>
+
+        {/* Upcoming capabilities */}
+        <View className="w-full gap-3">
+          {[
+            { icon: 'bar-chart-2', label: 'Performance insights based on your activity data' },
+            { icon: 'zap',         label: 'Daily motivation nudges tailored to your goals' },
+            { icon: 'target',      label: 'Challenge strategy and league standing tips' },
+            { icon: 'shield',      label: 'Private — visible only to you, not the team' },
+          ].map((item) => (
+            <View
+              key={item.icon}
+              className="flex-row items-center gap-3 rounded-xl px-4 py-3"
+              style={{ backgroundColor: mflColors.card, borderWidth: 1, borderColor: mflColors.border }}
+            >
+              <Feather name={item.icon as any} size={18} color={mflColors.brand} />
+              <AppText className="flex-1 text-sm text-foreground">{item.label}</AppText>
+            </View>
+          ))}
+        </View>
       </View>
-      <View className="items-center pb-1">
-        <AppText className="text-[10px] text-muted">{input.length}/500</AppText>
-      </View>
-    </KeyboardAvoidingView>
+    </ScreenScrollView>
   );
 }

--- a/src/app/(app)/(tabs)/my-activity.tsx
+++ b/src/app/(app)/(tabs)/my-activity.tsx
@@ -9,6 +9,7 @@ import { ScreenScrollView } from '../../../components/screen-scroll-view';
 import { ScreenState } from '../../../components/screen-state';
 import { useLeagueContext } from '../../../contexts/league-context';
 import { useMySubmissions } from '../../../features/submissions/hooks/use-my-submissions';
+import { useLeagueActivities } from '../../../features/leagues/hooks/use-league-activities';
 import type { SubmissionEntry, SubmissionStats } from '../../../features/submissions/types/submission.model';
 import { isReuploadWindowOpen } from '../../../features/submissions/utils/reupload-window';
 import { mflColors } from '../../../constants/colors';
@@ -286,6 +287,64 @@ function SubmissionCard({
 }
 
 // ---------------------------------------------------------------------------
+// Monthly Grouped List
+// ---------------------------------------------------------------------------
+
+function getMonthLabel(isoDate: string): string {
+  const d = new Date(isoDate);
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function MonthlyGroupedList({
+  submissions,
+  resubmittableIds,
+  onPressEntry,
+  onReupload,
+}: {
+  submissions: SubmissionEntry[];
+  resubmittableIds: Set<string>;
+  onPressEntry: (id: string) => void;
+  onReupload: (id: string) => void;
+}) {
+  // Group by month label, preserving sort order (newest first)
+  const grouped = useMemo(() => {
+    const map = new Map<string, SubmissionEntry[]>();
+    for (const s of submissions) {
+      const label = getMonthLabel(s.date);
+      const existing = map.get(label) ?? [];
+      existing.push(s);
+      map.set(label, existing);
+    }
+    return Array.from(map.entries());
+  }, [submissions]);
+
+  return (
+    <View className="gap-4">
+      {grouped.map(([month, entries]) => (
+        <View key={month} className="gap-2">
+          <AppText className="text-xs font-bold uppercase tracking-wider text-muted px-1">
+            {month}
+          </AppText>
+          <View className="gap-3">
+            {entries.map((entry) => (
+              <SubmissionCard
+                key={entry.id}
+                entry={entry}
+                onPress={() => onPressEntry(entry.id)}
+                canResubmit={resubmittableIds.has(entry.id)}
+                onReupload={
+                  resubmittableIds.has(entry.id) ? () => onReupload(entry.id) : undefined
+                }
+              />
+            ))}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Screen
 // ---------------------------------------------------------------------------
 
@@ -296,6 +355,23 @@ export default function MyActivityScreen() {
   const isChallengesOnly = activeLeague?.leagueMode === 'challenges_only';
 
   const { data: submissionsData, isLoading, isError, refetch } = useMySubmissions(leagueId);
+  const { data: activities } = useLeagueActivities(leagueId || null);
+
+  // Determine the dominant frequency type across configured activities.
+  // Monthly leagues must NOT show a daily history view (Phase 2 requirement).
+  const dominantFrequency = useMemo<'daily' | 'weekly' | 'monthly'>(() => {
+    if (!activities || activities.length === 0) return 'weekly';
+    const counts = { daily: 0, weekly: 0, monthly: 0 };
+    for (const a of activities) {
+      const ft = a.frequency_type;
+      if (ft === 'monthly') counts.monthly++;
+      else if (ft === 'daily') counts.daily++;
+      else counts.weekly++;
+    }
+    if (counts.monthly > 0 && counts.monthly >= counts.weekly && counts.monthly >= counts.daily) return 'monthly';
+    if (counts.daily > counts.weekly) return 'daily';
+    return 'weekly';
+  }, [activities]);
 
   const submissions = submissionsData?.submissions ?? [];
   const stats = submissionsData?.stats ?? { total: 0, pending: 0, approved: 0, rejected: 0 };
@@ -390,7 +466,31 @@ export default function MyActivityScreen() {
           </Tabs.List>
         </Tabs>
 
-        {/* Submission list */}
+        {/* Frequency context banner — monthly leagues show submissions per period, not per day */}
+        {dominantFrequency === 'monthly' && (
+          <View
+            className="flex-row items-center gap-2 rounded-xl px-4 py-3"
+            style={{ backgroundColor: mflColors.brandLight, borderWidth: 1, borderColor: `${mflColors.brand}33` }}
+          >
+            <Feather name="calendar" size={14} color={mflColors.brand} />
+            <AppText className="flex-1 text-xs" style={{ color: mflColors.brand }}>
+              This league tracks activity monthly. Submissions are grouped by month.
+            </AppText>
+          </View>
+        )}
+        {dominantFrequency === 'weekly' && filteredSubmissions.length > 0 && (
+          <View
+            className="flex-row items-center gap-2 rounded-xl px-4 py-3"
+            style={{ backgroundColor: mflColors.inkLight }}
+          >
+            <Feather name="calendar" size={13} color={mflColors.textMuted} />
+            <AppText className="flex-1 text-xs text-muted">
+              Weekly league — one activity per week counts toward points.
+            </AppText>
+          </View>
+        )}
+
+        {/* Submission list — monthly leagues group by month, others show flat */}
         {filteredSubmissions.length === 0 ? (
           <ScreenState
             screen="my-activity"
@@ -405,6 +505,18 @@ export default function MyActivityScreen() {
               activeTab === 'All' && !isChallengesOnly
                 ? () => router.push('/(app)/log-activity' as any)
                 : undefined
+            }
+          />
+        ) : dominantFrequency === 'monthly' ? (
+          // Monthly view: group submissions by calendar month
+          <MonthlyGroupedList
+            submissions={filteredSubmissions}
+            resubmittableIds={resubmittableIds}
+            onPressEntry={(id) =>
+              router.push({ pathname: '/(app)/submission-detail' as any, params: { submissionId: id } })
+            }
+            onReupload={(id) =>
+              router.push({ pathname: '/(app)/reupload-submission' as any, params: { submissionId: id } })
             }
           />
         ) : (

--- a/src/app/(app)/(tabs)/my-team.tsx
+++ b/src/app/(app)/(tabs)/my-team.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { View, Modal, Pressable, ScrollView, TextInput } from 'react-native';
 import Feather from '@expo/vector-icons/Feather';
-import { Avatar, Button, Card, Chip, Tabs } from 'heroui-native';
+import { Avatar, Button, Card, Tabs } from 'heroui-native';
 import { TeamViewRoster } from '../../../features/team/components/team-view-roster';
 import { useRouter } from 'expo-router';
 import { AppText } from '../../../components/app-text';
@@ -125,7 +125,6 @@ export default function MyTeamScreen() {
             teamName={overviewData?.stats.teamName ?? activeLeague.teamName}
             teamLogoUrl={activeLeague.teamLogoUrl}
             overviewData={overviewData}
-            teamCapacity={teamCapacity}
             isLeader={isLeader}
             isCaptain={isCaptain}
             isViceCaptain={isViceCaptain}
@@ -183,7 +182,6 @@ interface RosterTabProps {
         };
       }
     | undefined;
-  teamCapacity: number;
   isLeader: boolean;
   isCaptain: boolean;
   isViceCaptain: boolean;
@@ -199,7 +197,6 @@ function RosterTab({
   teamName,
   teamLogoUrl,
   overviewData,
-  teamCapacity,
   isLeader,
   isCaptain,
   isViceCaptain,
@@ -274,17 +271,12 @@ function RosterTab({
         ) : null}
       </DarkHeaderCard>
 
-      {/* Stats Row */}
+      {/* Stats Summary Cards — Team Points · Run Rate · Ranking */}
       {stats && (
         <View className="flex-row gap-2">
-          <StatCard value={stats.teamRank} label="Rank" color={mflColors.amber} />
-          <StatCard value={String(stats.teamPoints)} label="Points" color={mflColors.brand} />
-          <StatCard value={stats.teamAvgRR.toFixed(1)} label="Avg RR" color={mflColors.blue} />
-          <StatCard
-            value={`${members.length}/${teamCapacity}`}
-            label="Members"
-            color={mflColors.ink}
-          />
+          <StatCard value={stats.teamRank} label="Team Ranking" color={mflColors.amber} />
+          <StatCard value={String(stats.teamPoints)} label="Team Points" color={mflColors.brand} />
+          <StatCard value={stats.teamAvgRR.toFixed(1)} label="Run Rate" color={mflColors.blue} />
         </View>
       )}
 
@@ -498,9 +490,14 @@ function UnallocatedMembersModal({
                     {member.username ?? 'Unknown'}
                   </AppText>
                   {member.roles.includes('host') && (
-                    <Chip size="sm" variant="soft">
-                      <Chip.Label>Host</Chip.Label>
-                    </Chip>
+                    <View
+                      className="rounded-full px-2 py-0.5"
+                      style={{ backgroundColor: mflColors.amberLight }}
+                    >
+                      <AppText className="text-[10px] font-semibold" style={{ color: mflColors.amber }}>
+                        Host
+                      </AppText>
+                    </View>
                   )}
                 </Pressable>
               );
@@ -567,9 +564,9 @@ function TeamsTab({ teams }: TeamsTabProps) {
               <AppText className="text-sm font-semibold text-foreground" numberOfLines={1}>
                 {team.teamName}
               </AppText>
-              <Chip size="sm" variant="soft">
-                <Chip.Label>{`${team.memberCount} ${team.memberCount === 1 ? 'member' : 'members'}`}</Chip.Label>
-              </Chip>
+              <AppText className="text-xs text-muted">
+                {`${team.memberCount} ${team.memberCount === 1 ? 'member' : 'members'}`}
+              </AppText>
             </View>
           </View>
         </Card>

--- a/src/app/(app)/wearables.tsx
+++ b/src/app/(app)/wearables.tsx
@@ -1,5 +1,85 @@
-import { ConnectedAppsScreen } from '../../features/wearables';
+import Feather from '@expo/vector-icons/Feather';
+import { Platform, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { AppText } from '../../components/app-text';
+import { ScreenScrollView } from '../../components/screen-scroll-view';
+import { mflColors } from '../../constants/colors';
 
+/**
+ * Wearable Sync — Coming Soon
+ *
+ * Replaces the previous ConnectedAppsScreen per Phase 2 UI review (09 Jun 2026).
+ * Health Connect (Android) and HealthKit (iOS) integration is in progress.
+ * The screen remains accessible but non-functional until ready.
+ */
 export default function WearablesRoute() {
-  return <ConnectedAppsScreen />;
+  const insets = useSafeAreaInsets();
+  const isAndroid = Platform.OS === 'android';
+  const isIos = Platform.OS === 'ios';
+
+  return (
+    <ScreenScrollView>
+      <View
+        className="flex-1 items-center justify-center px-8"
+        style={{ paddingTop: insets.top + 48, paddingBottom: 48, gap: 24 }}
+      >
+        {/* Icon */}
+        <View
+          className="w-20 h-20 rounded-2xl items-center justify-center"
+          style={{ backgroundColor: mflColors.accentLight }}
+        >
+          <Feather name="watch" size={36} color={mflColors.blue} />
+        </View>
+
+        {/* Title */}
+        <View className="items-center gap-2">
+          <AppText className="text-2xl font-bold text-foreground text-center">
+            Wearable Sync
+          </AppText>
+          <View
+            className="flex-row items-center gap-2 rounded-full px-4 py-1.5"
+            style={{ backgroundColor: mflColors.amberLight }}
+          >
+            <Feather name="clock" size={13} color={mflColors.amber} />
+            <AppText className="text-xs font-semibold" style={{ color: mflColors.amber }}>
+              Coming Soon
+            </AppText>
+          </View>
+        </View>
+
+        {/* Description */}
+        <AppText className="text-sm text-muted text-center leading-6 max-w-xs">
+          Connect your fitness device or health app to automatically sync
+          workouts and have them appear in your activity log — no manual entry
+          required.
+        </AppText>
+
+        {/* Upcoming capabilities */}
+        <View className="w-full gap-3">
+          {[
+            {
+              icon: 'smartphone',
+              label: isAndroid
+                ? 'Health Connect (Android) — auto-detect workouts'
+                : isIos
+                  ? 'Apple HealthKit — auto-detect workouts'
+                  : 'Health Connect & Apple HealthKit support',
+            },
+            { icon: 'refresh-cw',  label: 'Automatic sync after each workout' },
+            { icon: 'check-circle', label: 'One-tap confirmation before points are awarded' },
+            { icon: 'shield',      label: 'Duplicate prevention — no accidental double-counts' },
+          ].map((item) => (
+            <View
+              key={item.icon}
+              className="flex-row items-center gap-3 rounded-xl px-4 py-3"
+              style={{ backgroundColor: mflColors.card, borderWidth: 1, borderColor: mflColors.border }}
+            >
+              <Feather name={item.icon as any} size={18} color={mflColors.blue} />
+              <AppText className="flex-1 text-sm text-foreground">{item.label}</AppText>
+            </View>
+          ))}
+        </View>
+      </View>
+    </ScreenScrollView>
+  );
 }

--- a/src/features/messaging/components/chat-composer.tsx
+++ b/src/features/messaging/components/chat-composer.tsx
@@ -1,7 +1,7 @@
 import Feather from '@expo/vector-icons/Feather';
 import * as ImagePicker from 'expo-image-picker';
 import type React from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Image,
@@ -39,6 +39,11 @@ import { MessagingChip } from './messaging-chip';
 
 type ComposerModal = 'quick' | 'mention' | 'link' | null;
 
+/** Imperative handle exposed to parent via ref */
+export interface ChatComposerHandle {
+  focusInput: () => void;
+}
+
 interface ChatComposerProps {
   leagueId: string;
   teamId: string | null;
@@ -54,7 +59,7 @@ interface ChatComposerProps {
   onSendFailed?: (messageId: string) => void;
 }
 
-export function ChatComposer({
+export const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function ChatComposer({
   leagueId,
   teamId,
   currentRole,
@@ -67,7 +72,7 @@ export function ChatComposer({
   senderUsername,
   onOptimisticMessage,
   onSendFailed,
-}: ChatComposerProps) {
+}: ChatComposerProps, ref) {
   const sendMutation = useSendChatMessage();
   const [content, setContent] = useState('');
   const [visibility, setVisibility] = useState<ChatVisibility>('all');
@@ -78,6 +83,13 @@ export function ChatComposer({
   const [uploadingPhoto, setUploadingPhoto] = useState(false);
   const [motivating, setMotivating] = useState(false);
   const [modal, setModal] = useState<ComposerModal>(null);
+
+  // Ref to the text input so the empty-state CTA can focus it
+  const inputRef = useRef<TextInput>(null);
+
+  useImperativeHandle(ref, () => ({
+    focusInput: () => inputRef.current?.focus(),
+  }));
 
   const cannedQuery = useCannedMessages(leagueId, modal === 'quick');
   const membersQuery = useChatMembers(leagueId, modal === 'mention');
@@ -399,7 +411,7 @@ export function ChatComposer({
           ) : null}
           {isCaptainRole && teamId ? (
             <MessagingChip
-              label={motivating ? 'Writing' : 'Motivate'}
+              label={motivating ? 'Writing...' : 'Send Motivation'}
               icon="zap"
               disabled={motivating}
               onPress={handleMotivate}
@@ -411,6 +423,7 @@ export function ChatComposer({
 
       <View className="flex-row items-end gap-2">
         <TextInput
+          ref={inputRef}
           className="flex-1 rounded-2xl px-4 py-2 text-sm"
           style={{
             minHeight: 42,
@@ -518,7 +531,7 @@ export function ChatComposer({
       </PickerModal>
     </View>
   );
-}
+});
 
 function PickerModal({
   visible,

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -365,9 +365,9 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
                 className="mt-3 flex-row items-center gap-2 rounded-xl px-5 py-3"
                 style={{ backgroundColor: mflColors.brand }}
               >
-                <Feather name="zap" size={15} color={mflColors.white} />
+                <Feather name={isCaptainRole ? 'zap' : 'message-circle'} size={15} color={mflColors.white} />
                 <AppText className="text-sm font-semibold" style={{ color: mflColors.white }}>
-                  Send Motivation
+                  {isCaptainRole ? 'Send Motivation' : 'Start Chatting'}
                 </AppText>
               </Pressable>
             ) : null}

--- a/src/features/messaging/components/team-messaging-screen.tsx
+++ b/src/features/messaging/components/team-messaging-screen.tsx
@@ -33,7 +33,7 @@ import type {
 } from '../types/messaging.model';
 import { messagingQueryKeys } from '../utils/messaging-query-keys';
 import { ChatChannelSelector } from './chat-channel-selector';
-import { ChatComposer } from './chat-composer';
+import { ChatComposer, type ChatComposerHandle } from './chat-composer';
 import { ChatMessageBubble } from './chat-message-bubble';
 import { MessagingChip } from './messaging-chip';
 
@@ -69,6 +69,9 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
   const [filter, setFilter] = useState<ChatFilter>('all');
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Ref to let the empty-state CTA focus the composer input
+  const composerRef = useRef<ChatComposerHandle>(null);
 
   useEffect(() => {
     if (!selectedTeamId) setAdminView(false);
@@ -256,7 +259,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
         </View>
       </View>
 
-      <View className="gap-3 px-4 py-3">
+      <View className="gap-2 px-4 pt-3 pb-2">
         {isLeader ? (
           <ChatChannelSelector
             teams={teams}
@@ -272,7 +275,13 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
           />
         ) : null}
 
-        <View className="flex-row flex-wrap gap-2">
+        {/* Filter chips — horizontal scroll prevents overflow on narrow screens */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ gap: 8, paddingRight: 8 }}
+          keyboardShouldPersistTaps="handled"
+        >
           {FILTER_OPTIONS.map((option) => (
             <MessagingChip
               key={option.value}
@@ -281,7 +290,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
               onPress={() => setFilter(option.value)}
             />
           ))}
-        </View>
+        </ScrollView>
       </View>
 
       {pinnedMessage ? (
@@ -328,19 +337,40 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
             contentContainerStyle={{
               flexGrow: 1,
               justifyContent: 'center',
-              paddingHorizontal: 16,
+              alignItems: 'center',
+              paddingHorizontal: 24,
               paddingVertical: 48,
+              gap: 8,
             }}
             refreshControl={
               <RefreshControl refreshing={refreshing} onRefresh={refresh} />
             }
             keyboardShouldPersistTaps="handled"
           >
-            <AppText className="text-sm text-muted text-center">
-              {filter === 'all'
-                ? 'No messages yet.'
-                : `No ${FILTER_OPTIONS.find((option) => option.value === filter)?.label.toLowerCase()} messages.`}
+            <View
+              className="w-14 h-14 rounded-2xl items-center justify-center mb-2"
+              style={{ backgroundColor: mflColors.brandLight }}
+            >
+              <Feather name="message-circle" size={28} color={mflColors.brand} />
+            </View>
+            <AppText className="text-sm font-semibold text-foreground text-center">
+              {filter === 'all' ? 'No messages yet' : `No ${FILTER_OPTIONS.find((o) => o.value === filter)?.label.toLowerCase()} messages`}
             </AppText>
+            <AppText className="text-xs text-muted text-center">
+              {filter === 'all' ? 'Be the first to start the conversation!' : 'Try switching to "All" to see all messages.'}
+            </AppText>
+            {filter === 'all' ? (
+              <Pressable
+                onPress={() => composerRef.current?.focusInput()}
+                className="mt-3 flex-row items-center gap-2 rounded-xl px-5 py-3"
+                style={{ backgroundColor: mflColors.brand }}
+              >
+                <Feather name="zap" size={15} color={mflColors.white} />
+                <AppText className="text-sm font-semibold" style={{ color: mflColors.white }}>
+                  Send Motivation
+                </AppText>
+              </Pressable>
+            ) : null}
           </ScrollView>
         ) : (
           <FlatList
@@ -374,6 +404,7 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
       ) : (
         <View style={{ paddingBottom: Math.max(insets.bottom, 8), backgroundColor: mflColors.card }}>
           <ChatComposer
+            ref={composerRef}
             leagueId={leagueId}
             teamId={channelTeamId}
             currentRole={activeRole}
@@ -382,8 +413,10 @@ export function TeamMessagingScreen({ league }: TeamMessagingScreenProps) {
             replyTo={replyTo}
             onCancelReply={() => setReplyTo(null)}
             onSent={() => {
-              messagesQuery.refetch();
-              unreadQuery.refetch();
+              // Invalidate in the background — keeps optimistic message visible
+              // until the server response replaces it, preventing the disappearance bug.
+              queryClient.invalidateQueries({ queryKey: activeQueryKey });
+              queryClient.invalidateQueries({ queryKey: messagingQueryKeys.unread(leagueId) });
             }}
             senderId={user?.id}
             senderUsername={profileQuery.data?.username}
@@ -417,3 +450,4 @@ function getDeepLinkSection(path: string): string | null {
   if (match?.[1]) return match[1].split('/')[0] ?? null;
   return normalized.split('/').filter(Boolean).at(-1) ?? null;
 }
+


### PR DESCRIPTION
## Summary
Implements mobile parity for Phase 2 UI review feedback (#65). All applicable checklist items addressed across 6 files.

## High Priority

**Team Chat mobile layout**
- Filter chips moved into horizontal `ScrollView` — no overflow on narrow screens
- Spacing tightened (`gap-2 px-4 pt-3 pb-2`)

**Team Chat empty state CTA**
- Replaced plain "No messages yet." text with icon + heading + subtext + "Send Motivation" CTA button
- CTA focuses the composer input via `composerRef` / `ChatComposerHandle` imperative ref

**Team Chat message disappearance**
- Replaced `messagesQuery.refetch()` on send success with `queryClient.invalidateQueries` — optimistic message stays visible during background refetch

**Team Chat terminology**
- Renamed "Motivate" chip to "Send Motivation" in `chat-composer.tsx`

**My Team screen cleanup**
- Stats row now shows Team Ranking, Team Points, Run Rate only — removed Members card
- Removed duplicate member count `Chip` in TeamsTab — replaced with plain `AppText`
- Removed unused `Chip` import and `teamCapacity` prop from `RosterTab`

## Coming Soon Placeholders

**AI Coach → Coming Soon**
- `coach.tsx` replaced with full Coming Soon placeholder screen

**Wearables → Coming Soon**
- `wearables.tsx` replaced with full Coming Soon placeholder screen

**Activity history monthly grouping**
- `my-activity.tsx` groups history by month for monthly-frequency leagues

## N/A on mobile
- Onboarding popups, notification permission prompts, V3 feature popups — do not exist in the mobile codebase, web-only

## Files changed
- `src/app/(app)/(tabs)/coach.tsx`
- `src/app/(app)/(tabs)/wearables.tsx`
- `src/app/(app)/(tabs)/my-activity.tsx`
- `src/features/messaging/components/chat-composer.tsx`
- `src/features/messaging/components/team-messaging-screen.tsx`
- `src/app/(app)/(tabs)/my-team.tsx`

## Tested
- Team chat — filter chips scroll correctly on small screens
- Team chat — empty state CTA focuses composer input
- Team chat — messages stay visible after sending
- My Team — stats row shows 3 cards, no duplicate member count
- AI Coach — Coming Soon screen renders
- Wearables — Coming Soon screen renders
- Activity history — monthly grouping correct for monthly leagues

## Impact
Mobile only — chat, team, coach, wearables, activity screens

## Risk
Low — UI layout changes, label renames, ref wiring, query invalidation fix. No breaking logic changes.

## Closes
Part of #65