### PR TITLE
fix(BUG-008): round RR/points to 2dp in my-activity submission cards

### DIFF
--- a/src/app/(app)/(tabs)/my-activity.tsx
+++ b/src/app/(app)/(tabs)/my-activity.tsx
@@ -139,7 +139,13 @@ function SubmissionCard({
   const chipStyle = getStatusChipStyle(entry.status);
   const isWorkout = entry.type === 'workout';
   const isExemption = isExemptionRequest(entry);
-  const points = entry.effectivePoints ?? entry.rrValue;
+  const rawPoints = entry.effectivePoints ?? entry.rrValue;
+  const points =
+    rawPoints != null
+      ? Number.isInteger(rawPoints)
+        ? rawPoints
+        : parseFloat(rawPoints.toFixed(2))
+      : null;
 
   return (
     <Pressable onPress={onPress}>


### PR DESCRIPTION
## Summary

Aligns the mobile activity log points rendering to ensure raw float values from the database do not display long repeating decimal places.

## What changed

Before: `my-activity.tsx` rendered raw floats like `1.3333333 pts` directly from `effectivePoints ?? rrValue`.
After: Implemented a fallback using `Number.isInteger()` and `toFixed(2)` to format floating-point values down to a clean two-decimal-place presentation while leaving integers unaffected.

Final points mapping logic applied inside `SubmissionCard`.

## Files Modified

* `src/app/(app)/my-activity.tsx`

## Testing

Open My Activity — verify non-integer point totals round correctly to two decimal places and do not trailing-render floats.

## Impact

Mobile app — activity history list view only. No logic changes.

## Risk

Low — minor local UI variable update only. No routing, database mutations, or schema modifications.