### PR TITLE
fix: default activity submission to same-day only

### DIFF
--- a/src/features/activity-submission/components/rest-day-submission.tsx
+++ b/src/features/activity-submission/components/rest-day-submission.tsx
@@ -8,7 +8,6 @@ import { useUpsertEntry } from '../../submissions';
 import { useRestDays } from '../../rest-days';
 import {
   todayISO,
-  yesterdayISO,
   formatDisplayDate,
   shiftDateISO,
   clampDate,
@@ -29,7 +28,6 @@ export function RestDaySubmission({ leagueId, league, onSuccess }: Props) {
   const { data: restDayStats, isLoading: statsLoading } = useRestDays(leagueId);
 
   const today = todayISO();
-  const yesterday = yesterdayISO();
 
   const leagueStartDate = useMemo(() => {
     if (!league.startDate) return null;
@@ -50,8 +48,9 @@ export function RestDaySubmission({ leagueId, league, onSuccess }: Props) {
     if (leagueStartDate && compareDates(today, leagueStartDate) < 0) {
       return shiftDateISO(leagueStartDate, -3);
     }
-    return compareDates(maxDate, yesterday) < 0 ? maxDate : yesterday;
-  }, [maxDate, yesterday, leagueStartDate, today]);
+    // Default: today only
+    return compareDates(maxDate, today) < 0 ? maxDate : today;
+  }, [maxDate, today, leagueStartDate]);
 
   const [entryDate, setEntryDate] = useState(() => clampDate(today, minDate, maxDate));
   const [reason, setReason] = useState('');
@@ -147,8 +146,8 @@ export function RestDaySubmission({ leagueId, league, onSuccess }: Props) {
         <AppText className="text-sm font-semibold text-muted">Date</AppText>
         <View className="bg-card rounded-xl border border-separator p-3">
           <View className="flex-row items-center justify-between">
-            <Pressable onPress={() => shiftDate(-1)} hitSlop={8}>
-              <Feather name="chevron-left" size={22} color={mflColors.text} />
+            <Pressable onPress={() => shiftDate(-1)} hitSlop={8} disabled={compareDates(entryDate, minDate) <= 0}>
+              <Feather name="chevron-left" size={22} color={compareDates(entryDate, minDate) <= 0 ? mflColors.textMuted : mflColors.text} />
             </Pressable>
             <AppText className="text-base font-medium text-foreground">
               {formatDisplayDate(entryDate)}

--- a/src/features/activity-submission/components/workout-submission.tsx
+++ b/src/features/activity-submission/components/workout-submission.tsx
@@ -18,7 +18,6 @@ import { OcrSuggestionPanel } from './ocr-suggestion-panel';
 import {
   validateWorkoutForm,
   todayISO,
-  yesterdayISO,
   formatDisplayDate,
   shiftDateISO,
   clampDate,
@@ -78,7 +77,6 @@ export function WorkoutSubmission({
 
   // -- Date boundaries --
   const today = todayISO();
-  const yesterday = yesterdayISO();
 
   const leagueStartDate = useMemo(() => {
     if (!league.startDate) return null;
@@ -104,16 +102,17 @@ export function WorkoutSubmission({
     // Monthly: any date from league start
     if (isMonthlyFrequency && leagueStartDate) return leagueStartDate;
     // Per-activity submission_window_days
-    if (selectedActivity?.submission_window_days) {
-      const windowStart = shiftDateISO(today, -(selectedActivity.submission_window_days - 1));
+    const swd = selectedActivity?.submission_window_days;
+    if (typeof swd === 'number' && swd >= 1) {
+      const windowStart = shiftDateISO(today, -swd);
       if (leagueStartDate && compareDates(windowStart, leagueStartDate) < 0) {
         return leagueStartDate;
       }
       return windowStart;
     }
-    // Default: yesterday or maxActivityDate (whichever is earlier)
-    return compareDates(maxActivityDate, yesterday) < 0 ? maxActivityDate : yesterday;
-  }, [maxActivityDate, yesterday, leagueStartDate, today, isMonthlyFrequency, selectedActivity]);
+    // Default: today only
+    return compareDates(maxActivityDate, today) < 0 ? maxActivityDate : today;
+  }, [maxActivityDate, leagueStartDate, today, isMonthlyFrequency, selectedActivity]);
 
   // -- Rest of form state --
   const [duration, setDuration] = useState(resubmitParams?.duration ?? '30');
@@ -395,8 +394,8 @@ export function WorkoutSubmission({
             </View>
             <View className="bg-card rounded-xl border border-separator p-2">
               <View className="flex-row items-center justify-between">
-                <Pressable onPress={() => shiftDate(-1)} hitSlop={8} disabled={isResubmit}>
-                  <Feather name="chevron-left" size={18} color={isResubmit ? mflColors.textMuted : mflColors.text} />
+                <Pressable onPress={() => shiftDate(-1)} hitSlop={8} disabled={isResubmit || compareDates(entryDate, minActivityDate) <= 0}>
+                  <Feather name="chevron-left" size={18} color={isResubmit || compareDates(entryDate, minActivityDate) <= 0 ? mflColors.textMuted : mflColors.text} />
                 </Pressable>
                 <AppText className="text-xs font-medium text-foreground text-center">
                   {formatDisplayDate(entryDate)}


### PR DESCRIPTION
## Summary
- Workout and rest day date bounds default to today-only unless `submission_window_days` is configured on the activity
- Left date chevron disabled and muted when at minimum date
- Removed unused `yesterdayISO` imports and variables

## Test plan
- [ ] Activity with no `submission_window_days`: date locked to today, left chevron disabled
- [ ] Activity with `submission_window_days=1`: can navigate to yesterday
- [ ] Activity with `submission_window_days>1`: can navigate back N days
- [ ] Rest day: date locked to today, left chevron disabled
- [ ] Backend still rejects yesterday when no window configured