### PR TITLE
fix(ai-manager): group alerts by trigger type with severity ordering

### DIFF
--- a/src/features/ai-manager/components/dashboard-section.tsx
+++ b/src/features/ai-manager/components/dashboard-section.tsx
@@ -30,6 +30,18 @@ export function DashboardSection({
 }: DashboardSectionProps) {
   const unreadDigest = digestItems.filter((d) => d.status === 'unread');
   const pendingAlerts = interventions.filter((i) => i.status === 'pending');
+  const groupedAlerts = pendingAlerts.reduce<Record<string, Intervention[]>>((acc, alert) => {
+    const key = alert.triggerType ?? 'other';
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(alert);
+    return acc;
+  }, {});
+  const severityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  const sortedGroupEntries = Object.entries(groupedAlerts).sort(([, a], [, b]) => {
+    const aSeverity = severityOrder[a[0]?.severity ?? ''] ?? 3;
+    const bSeverity = severityOrder[b[0]?.severity ?? ''] ?? 3;
+    return aSeverity - bSeverity;
+  });
 
   return (
     <View>
@@ -37,7 +49,9 @@ export function DashboardSection({
       <View className="flex-row items-center justify-between mb-2">
         <SectionLabel label="Alerts" />
         {pendingAlerts.length > 0 && (
-          <AppText className="text-xs text-muted">({pendingAlerts.length} pending)</AppText>
+          <AppText className="text-xs text-muted">
+            ({pendingAlerts.length} pending · {Object.keys(groupedAlerts).length} types)
+          </AppText>
         )}
       </View>
 
@@ -48,14 +62,33 @@ export function DashboardSection({
           </AppText>
         </Card>
       ) : (
-        interventions.map((alert) => (
-          <AlertCard
-            key={alert.id}
-            alert={alert}
-            isGenerating={generatingIntId === alert.id}
-            onGenerateDraft={onGenerateDraft}
-            onDismiss={(id) => onDismissIntervention([id])}
-          />
+        sortedGroupEntries.map(([triggerType, alerts]) => (
+          <View key={triggerType} className="mb-3">
+            <View className="flex-row items-center justify-between mb-1.5">
+              <AppText
+                className="text-xs font-semibold uppercase tracking-wide"
+                style={{ color: mflColors.textSub }}
+              >
+                {triggerType.replace(/_/g, ' ')} · {alerts.length}
+              </AppText>
+              {alerts.length > 1 && (
+                <Pressable onPress={() => onDismissIntervention(alerts.map((a) => a.id))}>
+                  <AppText className="text-xs font-medium" style={{ color: mflColors.danger }}>
+                    Dismiss all
+                  </AppText>
+                </Pressable>
+              )}
+            </View>
+            {alerts.map((alert) => (
+              <AlertCard
+                key={alert.id}
+                alert={alert}
+                isGenerating={generatingIntId === alert.id}
+                onGenerateDraft={onGenerateDraft}
+                onDismiss={(id) => onDismissIntervention([id])}
+              />
+            ))}
+          </View>
         ))
       )}
 

--- a/src/features/ai-manager/components/dashboard-section.tsx
+++ b/src/features/ai-manager/components/dashboard-section.tsx
@@ -37,11 +37,12 @@ export function DashboardSection({
     return acc;
   }, {});
   const severityOrder: Record<string, number> = { high: 0, medium: 1, low: 2 };
-  const sortedGroupEntries = Object.entries(groupedAlerts).sort(([, a], [, b]) => {
-    const aSeverity = severityOrder[a[0]?.severity ?? ''] ?? 3;
-    const bSeverity = severityOrder[b[0]?.severity ?? ''] ?? 3;
-    return aSeverity - bSeverity;
-  });
+  function groupSeverity(alerts: Intervention[]): number {
+    return Math.min(...alerts.map((a) => severityOrder[a.severity] ?? 3));
+  }
+  const sortedGroupEntries = Object.entries(groupedAlerts).sort(
+    ([, a], [, b]) => groupSeverity(a) - groupSeverity(b)
+  );
 
   return (
     <View>
@@ -55,7 +56,7 @@ export function DashboardSection({
         )}
       </View>
 
-      {interventions.length === 0 ? (
+      {pendingAlerts.length === 0 ? (
         <Card className="p-4 mb-4">
           <AppText className="text-xs text-muted text-center py-4">
             No alerts. Run a scan to check for at-risk members.


### PR DESCRIPTION
Closes #78 
Alerts in the AI Manager dashboard were rendering as a flat list — one card per intervention — which meant 100+ cards for large leagues with no way to act on them in bulk.

## Changes

- Grouped pending alerts by triggerType in dashboard-section.tsx
- Groups are sorted by severity (high → medium → low)
- Each group with 2+ alerts gets a "Dismiss all" button that bulk-dismisses the entire group
- Section header now shows total pending count and number of distinct alert types
- No changes to hooks, services, or API contracts

## Testing

- Verified grouping renders correctly with mixed triggerType values
- Verified severity ordering (high groups appear above medium/low)
- Verified "Dismiss all" calls onDismissIntervention with all IDs in the group
- Verified single-alert groups do not show "Dismiss all"

## Files changed

src/features/ai-manager/components/dashboard-section.tsx