### PR TITLE
fix(leaderboard): add deterministic colour badges for team initials

### DIFF
--- a/src/features/leaderboard/components/ranking-cards.tsx
+++ b/src/features/leaderboard/components/ranking-cards.tsx
@@ -10,6 +10,16 @@ import {
 } from '../utils/leaderboard-format';
 import { RankBadge } from './rank-badge';
 
+function stringToColor(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    hash ^= hash >>> 16;
+  }
+  const h = ((Math.abs(hash) * 2654435761) >>> 0) % 360;
+  return `hsl(${h}, 55%, 82%)`;
+}
+
 export function TeamRankingCard({
   team,
   showAvgRR,
@@ -29,7 +39,7 @@ export function TeamRankingCard({
 
           <View
             className="h-8 w-8 items-center justify-center rounded-lg"
-            style={{ backgroundColor: mflColors.inkLight, overflow: 'hidden' }}
+            style={{ backgroundColor: stringToColor(team.team_name), overflow: 'hidden' }}
           >
             {team.logo_url ? (
               <Image
@@ -38,7 +48,7 @@ export function TeamRankingCard({
                 resizeMode="cover"
               />
             ) : (
-              <AppText className="text-[10px] font-bold text-muted">
+              <AppText className="text-[10px] font-bold" style={{ color: '#1a1a1a' }}>
                 {getInitials(team.team_name)}
               </AppText>
             )}

--- a/src/features/leaderboard/components/ranking-cards.tsx
+++ b/src/features/leaderboard/components/ranking-cards.tsx
@@ -48,7 +48,7 @@ export function TeamRankingCard({
                 resizeMode="cover"
               />
             ) : (
-              <AppText className="text-[10px] font-bold" style={{ color: '#1a1a1a' }}>
+              <AppText className="text-[10px] font-bold" style={{ color: mflColors.ink }}>
                 {getInitials(team.team_name)}
               </AppText>
             )}


### PR DESCRIPTION
Closes #87 

Team cards on the leaderboard showed plain grey initials badges with no visual identity. Each team now gets a unique, deterministic background colour derived from its name.

## Changes

- Added stringToColor utility using Knuth multiplicative hashing for even colour distribution
- Team initials badge background now uses the generated colour instead of flat grey
- Initials text switched to dark (#1a1a1a) for readability on light backgrounds
- Logo display unchanged — colour only shows when no logo_url is present

## Files changed

src/features/leaderboard/components/ranking-cards.tsx