### PR TITLE
fix(dashboard): hide Log Activity button for host/governor with no team

### DIFF
--- a/src/app/(app)/(tabs)/dashboard.tsx
+++ b/src/app/(app)/(tabs)/dashboard.tsx
@@ -381,24 +381,26 @@ export default function DashboardScreen() {
         </View>
 
         {/* ── Quick Actions ────────────────────────────────────── */}
-        {isChallengesOnly ? (
-          <Button
-            variant="primary"
-            size="lg"
-            onPress={() => router.push(AppRoutes.challenges)}
-            className="w-full"
-          >
-            <Button.Label>View Challenges</Button.Label>
-          </Button>
-        ) : (
-          <Button
-            variant="primary"
-            size="lg"
-            onPress={() => router.push(AppRoutes.myActivity)}
-            className="w-full"
-          >
-            <Button.Label>Log Activity</Button.Label>
-          </Button>
+        {((!isHost && !isGovernor) || !!activeLeague?.teamName) && (
+          isChallengesOnly ? (
+            <Button
+              variant="primary"
+              size="lg"
+              onPress={() => router.push(AppRoutes.challenges)}
+              className="w-full"
+            >
+              <Button.Label>View Challenges</Button.Label>
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="lg"
+              onPress={() => router.push(AppRoutes.myActivity)}
+              className="w-full"
+            >
+              <Button.Label>Log Activity</Button.Label>
+            </Button>
+          )
         )}
 
         {/* ── Host / Admin Quick Actions ────────────────────── */}


### PR DESCRIPTION
Closes #73 

The Log Activity and View Challenges buttons were rendering unconditionally for all roles. A Governor or Host with no team assigned could see and tap them, mirroring the web bug.

## Changes

- Wrapped the Quick Actions button block in dashboard.tsx with a guard: hidden for hosts/governors unless they have a team assigned (activeLeague?.teamName)
- Players are unaffected — button renders as before

## Files changed

src/app/(app)/(tabs)/dashboard.tsx