### PR TITLE
fix(BUG-008): round RR/points to 2dp in submission-detail points display

### DIFF
--- a/src/app/(app)/submission-detail.tsx
+++ b/src/app/(app)/submission-detail.tsx
@@ -67,7 +67,13 @@ export default function SubmissionDetailScreen() {
   const isSoftRejected = ['rejected', 'rejected_resubmit'].includes(submission.status);
   const isReupload = Boolean(submission.reuploadOf);
   const windowExpired = isSoftRejected && !canReuploadNow;
-  const points = submission.effectivePoints ?? submission.rrValue;
+  const rawPoints = submission.effectivePoints ?? submission.rrValue;
+  const points =
+    rawPoints != null
+      ? Number.isInteger(rawPoints)
+        ? rawPoints
+        : parseFloat(rawPoints.toFixed(2))
+      : null;
 
   const exemptionReason =
     isExemption && submission.notes


### PR DESCRIPTION
## Summary
Fix raw float display for Points Earned in submission detail screen — part of BUG-008 RR rounding audit.

## What was broken
`submission-detail.tsx` displayed `effectivePoints ?? rrValue` directly without rounding. Float RR values like `1.666...` were shown as-is.

## What was fixed
Applied the same rounding pattern from PR #90 — integers stay as integers, floats rounded to 2 decimal places via `parseFloat(rawPoints.toFixed(2))`.

## Tested
- Submission with integer points — displays as integer
- Submission with float RR — displays rounded to 2dp

## Files Modified
- `src/app/(app)/submission-detail.tsx`