### PR TITLE
feat(#96): add auto-rest-day info tooltip to log-activity screen

### DIFF
--- a/src/app/(app)/log-activity.tsx
+++ b/src/app/(app)/log-activity.tsx
@@ -1,6 +1,6 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useRouter, useLocalSearchParams } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   View,
   Pressable,
@@ -16,7 +16,9 @@ import { useRole } from '../../contexts/role-context';
 import { useLeagueActivities } from '../../features/leagues/hooks/use-league-activities';
 import { WorkoutSubmission } from '../../features/activity-submission/components/workout-submission';
 import { RestDaySubmission } from '../../features/activity-submission/components/rest-day-submission';
+import { AutoRestInfoCard, AutoRestInfoIcon } from '../../features/activity-submission/components/auto-rest-info-card';
 import { mflColors } from '../../constants/colors';
+import { mmkv, SEEN_AUTO_REST_INFO_KEY } from '../../core/storage/mmkv';
 import type { ResubmitParams } from '../../features/activity-submission/types';
 
 export default function LogActivityScreen() {
@@ -78,6 +80,20 @@ export default function LogActivityScreen() {
     if (params.type === 'rest') return 'rest';
     return 'workout';
   });
+
+  // Auto-rest info card — shown once, dismissible, icon always visible
+  const [showAutoRestCard, setShowAutoRestCard] = useState(
+    () => !mmkv.getBoolean(SEEN_AUTO_REST_INFO_KEY),
+  );
+
+  const handleDismissAutoRestCard = useCallback(() => {
+    mmkv.set(SEEN_AUTO_REST_INFO_KEY, true);
+    setShowAutoRestCard(false);
+  }, []);
+
+  const handleReopenAutoRestCard = useCallback(() => {
+    setShowAutoRestCard(true);
+  }, []);
 
   const handleSuccess = () => router.back();
 
@@ -192,7 +208,7 @@ export default function LogActivityScreen() {
             </Pressable>
             <Pressable
               onPress={() => setTab('rest')}
-              className={`flex-1 py-2.5 rounded-lg items-center ${
+              className={`flex-1 py-2.5 rounded-lg items-center flex-row justify-center gap-1 ${
                 tab === 'rest' ? 'bg-card shadow-sm' : ''
               }`}
             >
@@ -203,8 +219,17 @@ export default function LogActivityScreen() {
               >
                 Rest Day
               </AppText>
+              <AutoRestInfoIcon onPress={handleReopenAutoRestCard} />
             </Pressable>
           </View>
+        )}
+
+        {/* Auto-rest day info card (one-time, dismissible) */}
+        {showRestDays && !resubmitParams && tab === 'rest' && (
+          <AutoRestInfoCard
+            showCard={showAutoRestCard}
+            onDismiss={handleDismissAutoRestCard}
+          />
         )}
 
         {/* Content */}

--- a/src/core/storage/mmkv.ts
+++ b/src/core/storage/mmkv.ts
@@ -5,6 +5,7 @@ export const mmkv = createMMKV({ id: 'mfl-app-storage' });
 // ─── Typed helpers for common keys ───
 
 const USER_CACHE_KEY = 'mfl_user_cache';
+export const SEEN_AUTO_REST_INFO_KEY = 'mfl_seen_auto_rest_info';
 
 export function getCachedUser<T>(): T | null {
   const raw = mmkv.getString(USER_CACHE_KEY);

--- a/src/features/activity-submission/components/auto-rest-info-card.tsx
+++ b/src/features/activity-submission/components/auto-rest-info-card.tsx
@@ -1,0 +1,54 @@
+import { Pressable, View } from 'react-native';
+import Feather from '@expo/vector-icons/Feather';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+
+interface AutoRestInfoCardProps {
+  /** Whether to show the full dismissible card (first-time view). */
+  showCard: boolean;
+  onDismiss: () => void;
+}
+
+const INFO_TEXT =
+  "If you're traveling and receive an automatic rest day, you can still submit your activity — the rest day will be replaced automatically.";
+
+/**
+ * Renders a dismissible one-time info card explaining auto-rest-day overwrite behavior.
+ * The ℹ️ icon is always visible even after dismissal so users can re-read.
+ */
+export function AutoRestInfoCard({ showCard, onDismiss }: AutoRestInfoCardProps) {
+  if (!showCard) return null;
+
+  return (
+    <View
+      className="rounded-xl p-3 gap-2"
+      style={{
+        backgroundColor: mflColors.blueLight,
+        borderWidth: 1,
+        borderColor: mflColors.blue + '30',
+      }}
+    >
+      <View className="flex-row items-start gap-2">
+        <Feather name="info" size={16} color={mflColors.blue} style={{ marginTop: 1 }} />
+        <AppText className="flex-1 text-xs" style={{ color: mflColors.blue }}>
+          {INFO_TEXT}
+        </AppText>
+        <Pressable onPress={onDismiss} hitSlop={8}>
+          <Feather name="x" size={16} color={mflColors.blue} />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+/**
+ * Standalone ℹ️ icon that always renders — tapping it re-opens the info card.
+ * Place this next to the "Rest Day" tab label.
+ */
+export function AutoRestInfoIcon({ onPress }: { onPress: () => void }) {
+  return (
+    <Pressable onPress={onPress} hitSlop={10} className="ml-1">
+      <Feather name="info" size={13} color={mflColors.textMuted} />
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary
Implements auto-rest day info tooltip on the Log Activity screen per issue #96.

## What was added
When a player switches to the Rest Day tab in a league that has rest days configured, a dismissible info card explains the auto-rest-day overwrite behavior. An ℹ️ icon is always visible in the Rest Day tab label so users can re-open the card after dismissal.

**Behavior:**
- Info card shown on first visit to Rest Day tab — persisted via MMKV (`mfl_seen_auto_rest_info`)
- Card is dismissible — won't show again after dismissal across restarts
- ℹ️ icon always visible next to "Rest Day" tab label — tapping re-opens the card
- Card only renders when `showRestDays` is true and tab is `rest` — zero impact on leagues without rest days or during resubmit flows

**Card content:**
"If you're traveling and receive an automatic rest day, you can still submit your activity — the rest day will be replaced automatically."

## Note on #97
`max_submissions_per_day` doesn't exist in the league model or backend API yet — blocked on `mfl#466`. Mobile implementation not possible until backend ships the field.

## Files Modified
- `src/features/activity-submission/components/auto-rest-info-card.tsx` (new)
- `src/core/storage/mmkv.ts`
- `src/app/(app)/log-activity.tsx`