### PR TITLE
refactor(module-9): fix as any casts in payment flow, type Razorpay i…

### DIFF
--- a/src/app/(app)/payment-checkout.tsx
+++ b/src/app/(app)/payment-checkout.tsx
@@ -17,7 +17,6 @@ import type {
   PaymentStatus,
   RazorpayOptions,
   RazorpaySuccessResponse,
-  RazorpaySdkError,
 } from '../../features/payments';
 
 // ─── Payment Status Chip ────────────────────────────────────────────────────
@@ -181,11 +180,16 @@ export default function PaymentCheckoutScreen() {
       await refetchHistory();
     } catch (err: unknown) {
       setState('error');
-      const sdkErr = err as RazorpaySdkError;
+      const sdkErr =
+        typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : {};
+      const errObj =
+        typeof sdkErr.error === 'object' && sdkErr.error !== null
+          ? (sdkErr.error as Record<string, unknown>)
+          : {};
       const message =
-        sdkErr?.error?.description ??
-        sdkErr?.description ??
-        sdkErr?.message ??
+        (errObj.description as string | undefined) ??
+        (sdkErr.description as string | undefined) ??
+        (sdkErr.message as string | undefined) ??
         'Payment failed. Please try again.';
       setErrorMessage(message);
     }

--- a/src/app/(app)/payment-checkout.tsx
+++ b/src/app/(app)/payment-checkout.tsx
@@ -9,8 +9,16 @@ import { DarkHeaderCard } from '../../components/dark-header-card';
 import { ScreenScrollView } from '../../components/screen-scroll-view';
 import { SectionLabel } from '../../components/section-label';
 import { mflColors } from '../../constants/colors';
+import { AppRoutes } from '../../core/config/routes';
 import { useCreateOrder, useVerifyPayment, usePayments } from '../../features/payments';
-import type { PaymentOrder, Payment, PaymentStatus } from '../../features/payments';
+import type {
+  PaymentOrder,
+  Payment,
+  PaymentStatus,
+  RazorpayOptions,
+  RazorpaySuccessResponse,
+  RazorpaySdkError,
+} from '../../features/payments';
 
 // ─── Payment Status Chip ────────────────────────────────────────────────────
 
@@ -77,6 +85,21 @@ function PaymentHistoryCard({ payment }: { payment: Payment }) {
 
 type CheckoutState = 'idle' | 'creating-order' | 'paying' | 'verifying' | 'success' | 'error';
 
+interface LeagueDataParams {
+  tier_id?: string;
+  league_name?: string;
+  start_date?: string;
+  end_date?: string;
+  max_participants?: number;
+  num_teams?: number;
+  league_id?: string;
+  amount?: number;
+  rest_days?: number;
+  rr_config?: Record<string, unknown>;
+  is_public?: boolean;
+  is_exclusive?: boolean;
+}
+
 export default function PaymentCheckoutScreen() {
   const router = useRouter();
   const params = useLocalSearchParams<{
@@ -92,20 +115,7 @@ export default function PaymentCheckoutScreen() {
   const { data: paymentHistory, isLoading: historyLoading, refetch: refetchHistory } = usePayments();
 
   // Parse league data from route params
-  let leagueData: {
-    tier_id?: string;
-    league_name?: string;
-    start_date?: string;
-    end_date?: string;
-    max_participants?: number;
-    num_teams?: number;
-    league_id?: string;
-    amount?: number;
-    rest_days?: number;
-    rr_config?: any;
-    is_public?: boolean;
-    is_exclusive?: boolean;
-  } = {};
+  let leagueData: LeagueDataParams = {};
 
   try {
     if (params.leagueData) {
@@ -138,8 +148,15 @@ export default function PaymentCheckoutScreen() {
       setOrderData(order);
       setState('paying');
 
+      // Validate Razorpay key before opening checkout
+      if (!order.keyId) {
+        setState('error');
+        setErrorMessage('Payment configuration error. Please contact support.');
+        return;
+      }
+
       // Open Razorpay checkout
-      const options = {
+      const options: RazorpayOptions = {
         description: 'MFL League Payment',
         image: 'https://myfitnessleague.com/logo.png',
         currency: order.currency,
@@ -150,7 +167,7 @@ export default function PaymentCheckoutScreen() {
         theme: { color: mflColors.brand },
       };
 
-      const paymentData = await RazorpayCheckout.open(options);
+      const paymentData = await RazorpayCheckout.open(options) as RazorpaySuccessResponse;
 
       // Verify payment — field names must match web API: orderId, paymentId, signature
       setState('verifying');
@@ -162,11 +179,13 @@ export default function PaymentCheckoutScreen() {
 
       setState('success');
       await refetchHistory();
-    } catch (err: any) {
+    } catch (err: unknown) {
       setState('error');
+      const sdkErr = err as RazorpaySdkError;
       const message =
-        err?.error?.description ??
-        err?.message ??
+        sdkErr?.error?.description ??
+        sdkErr?.description ??
+        sdkErr?.message ??
         'Payment failed. Please try again.';
       setErrorMessage(message);
     }
@@ -184,7 +203,7 @@ export default function PaymentCheckoutScreen() {
   }, []);
 
   const handleGoToDashboard = useCallback(() => {
-    router.replace('/(app)/(tabs)/dashboard');
+    router.replace(AppRoutes.dashboard);
   }, [router]);
 
   const displayAmount = orderData

--- a/src/features/help/components/quick-links.tsx
+++ b/src/features/help/components/quick-links.tsx
@@ -2,6 +2,7 @@ import Feather from '@expo/vector-icons/Feather';
 import { useRouter } from 'expo-router';
 import { Pressable, ScrollView, View } from 'react-native';
 import { AppText } from '../../../components/app-text';
+import { AppRoutes } from '../../../core/config/routes';
 import type { FeatherIconName } from '../types';
 
 interface QuickLink {
@@ -21,21 +22,21 @@ export function QuickLinks() {
       icon: 'award',
       iconBg: '#E0E7FF',
       iconColor: '#4F46E5',
-      onPress: () => router.push('/(app)/host-support' as any),
+      onPress: () => router.push(AppRoutes.hostSupport),
     },
     {
       label: 'Profile',
       icon: 'user',
       iconBg: '#DCFCE7',
       iconColor: '#16A34A',
-      onPress: () => router.push('/(app)/profile' as any),
+      onPress: () => router.push(AppRoutes.profile),
     },
     {
       label: 'Payments',
       icon: 'credit-card',
       iconBg: '#FEF3C7',
       iconColor: '#D97706',
-      onPress: () => router.push('/(app)/payment-checkout' as any),
+      onPress: () => router.push(AppRoutes.paymentCheckout),
     },
   ];
 

--- a/src/features/payments/index.ts
+++ b/src/features/payments/index.ts
@@ -1,4 +1,12 @@
 export { usePayments } from './hooks/use-payments';
 export { useCreateOrder } from './hooks/use-create-order';
 export { useVerifyPayment } from './hooks/use-verify-payment';
-export type { Payment, PaymentOrder, PaymentStatus } from './types/payment.model';
+export type {
+  Payment,
+  PaymentOrder,
+  PaymentStatus,
+  RazorpayOptions,
+  RazorpaySuccessResponse,
+  RazorpayErrorResponse,
+  RazorpaySdkError,
+} from './types/payment.model';

--- a/src/features/payments/types/index.ts
+++ b/src/features/payments/types/index.ts
@@ -6,4 +6,12 @@ export type {
   VerifyPaymentRequestDTO,
   VerifyPaymentResponseDTO,
 } from './payment.dto';
-export type { Payment, PaymentOrder } from './payment.model';
+export type {
+  Payment,
+  PaymentOrder,
+  PaymentStatus,
+  RazorpayOptions,
+  RazorpaySuccessResponse,
+  RazorpayErrorResponse,
+  RazorpaySdkError,
+} from './payment.model';

--- a/src/features/payments/types/payment.dto.ts
+++ b/src/features/payments/types/payment.dto.ts
@@ -33,7 +33,7 @@ export interface CreateOrderRequestDTO {
     max_participants?: number;
     num_teams?: number;
     rest_days: number;
-    rr_config: any;
+    rr_config: Record<string, unknown>;
     is_public: boolean;
     is_exclusive: boolean;
   };

--- a/src/features/payments/types/payment.model.ts
+++ b/src/features/payments/types/payment.model.ts
@@ -25,3 +25,41 @@ export interface PaymentOrder {
   currency: string;
   keyId: string;
 }
+
+// ─── Razorpay SDK types ─────────────────────────────────────────────────────
+
+export interface RazorpayOptions {
+  description: string;
+  image: string;
+  currency: string;
+  key: string;
+  amount: number;
+  name: string;
+  order_id: string;
+  theme: { color: string };
+}
+
+export interface RazorpaySuccessResponse {
+  razorpay_order_id: string;
+  razorpay_payment_id: string;
+  razorpay_signature: string;
+}
+
+export interface RazorpayErrorResponse {
+  code: number;
+  description: string;
+  source: string;
+  step: string;
+  reason: string;
+  metadata: {
+    order_id: string;
+    payment_id: string;
+  };
+}
+
+/** Shape thrown by the Razorpay SDK on failure. */
+export interface RazorpaySdkError {
+  error?: RazorpayErrorResponse;
+  message?: string;
+  description?: string;
+}

--- a/src/features/settings/components/settings-content.tsx
+++ b/src/features/settings/components/settings-content.tsx
@@ -8,6 +8,7 @@ import { AppText } from '../../../components/app-text';
 import { SectionLabel } from '../../../components/section-label';
 import { mflColors } from '../../../constants/colors';
 import { useAuth } from '../../../core/auth';
+import { AppRoutes } from '../../../core/config/routes';
 import { SettingsMenuItem } from './settings-menu-item';
 
 export function SettingsContent() {
@@ -51,19 +52,19 @@ export function SettingsContent() {
           <SettingsMenuItem
             icon="shield"
             label="Privacy Policy"
-            onPress={() => router.push('/(app)/privacy-policy' as any)}
+            onPress={() => router.push(AppRoutes.privacyPolicy)}
           />
           <Separator />
           <SettingsMenuItem
             icon="help-circle"
             label="Help & Support"
-            onPress={() => router.push('/(app)/help' as any)}
+            onPress={() => router.push(AppRoutes.help)}
           />
           <Separator />
           <SettingsMenuItem
             icon="book-open"
             label="MFL Rules"
-            onPress={() => router.push('/(app)/mfl-rules' as any)}
+            onPress={() => router.push(AppRoutes.mflRules)}
           />
           <Separator />
           <SettingsMenuItem


### PR DESCRIPTION
## Summary
Module 9 refactor — Settings, Privacy, Help, Payment, Notifications. Fixes all `as any` casts in the payment flow, adds proper Razorpay SDK type interfaces, fixes route casts in settings and help, and adds Razorpay key validation.

## What was refactored

**`payment-checkout.tsx`**
- Extracted `LeagueDataParams` interface to module scope (was inline with `rr_config?: any`)
- `rr_config?: any` → `rr_config?: Record<string, unknown>`
- Added Razorpay key validation guard before `RazorpayCheckout.open()` — if `order.keyId` is falsy, sets error state with actionable message instead of crashing
- `RazorpayCheckout.open(options)` now typed with `RazorpayOptions` / cast to `RazorpaySuccessResponse`
- `err: any` in catch → `err: unknown` with `RazorpaySdkError` narrowing
- `router.replace('/(app)/(tabs)/dashboard')` → `router.replace(AppRoutes.dashboard)`

**`payment.model.ts`** — 4 new Razorpay SDK interfaces added:
- `RazorpayOptions` — typed options object for `RazorpayCheckout.open()`
- `RazorpaySuccessResponse` — typed success callback shape
- `RazorpayErrorResponse` — typed error response shape
- `RazorpaySdkError` — typed SDK error for catch blocks

**`payment.dto.ts`**
- `rr_config: any` → `rr_config: Record<string, unknown>`

**`payments/types/index.ts` and `payments/index.ts`**
- Exported the 4 new Razorpay types

**`settings-content.tsx`**
- Replaced 3 `as any` route casts with `AppRoutes.*`:
  - `'/(app)/privacy-policy' as any` → `AppRoutes.privacyPolicy`
  - `'/(app)/help' as any` → `AppRoutes.help`
  - `'/(app)/mfl-rules' as any` → `AppRoutes.mflRules`

**`quick-links.tsx`**
- Replaced 3 `as any` route casts with `AppRoutes.*`:
  - `'/(app)/host-support' as any` → `AppRoutes.hostSupport`
  - `'/(app)/profile' as any` → `AppRoutes.profile`
  - `'/(app)/payment-checkout' as any` → `AppRoutes.paymentCheckout`

**No changes needed:**
- `settings.tsx`, `notifications.tsx`, `help.tsx` — clean
- All `features/notifications/` files — clean
- `features/conversion/` files — clean
- `features/payments/services/`, `hooks/`, `mappers/` — clean
- `features/settings/data/`, other components — clean
- `features/help/data/`, other components — clean

## Files changed
- `src/app/(app)/payment-checkout.tsx`
- `src/features/payments/types/payment.model.ts`
- `src/features/payments/types/payment.dto.ts`
- `src/features/payments/types/index.ts`
- `src/features/payments/index.ts`
- `src/features/settings/components/settings-content.tsx`
- `src/features/help/components/quick-links.tsx`

## Tests
`npx tsc --noEmit` — zero errors across all Module 9 files.

## Manually tested
- Payment checkout — Razorpay flow works, key validation guard works
- Settings — all navigation links work
- Help quick links — all navigation links work

## Risk
Low — Razorpay type interfaces mirror the actual SDK contract. Route string values unchanged, only removed `as any` casts.

## Part of
Part of #58