### PR TITLE
refactor(module-8): extract typed UPCOMING_FEATURES constant, replace…

### DIFF
--- a/src/app/(app)/wearables.tsx
+++ b/src/app/(app)/wearables.tsx
@@ -5,6 +5,23 @@ import { AppText } from '../../components/app-text';
 import { ScreenScrollView } from '../../components/screen-scroll-view';
 import { mflColors } from '../../constants/colors';
 
+type FeatherIconName = React.ComponentProps<typeof Feather>['name'];
+
+const UPCOMING_FEATURES: Array<{ icon: FeatherIconName; label: string }> = [
+  {
+    icon: 'smartphone',
+    label:
+      Platform.OS === 'android'
+        ? 'Health Connect (Android) — auto-detect workouts'
+        : Platform.OS === 'ios'
+          ? 'Apple HealthKit — auto-detect workouts'
+          : 'Health Connect & Apple HealthKit support',
+  },
+  { icon: 'refresh-cw',   label: 'Automatic sync after each workout' },
+  { icon: 'check-circle', label: 'One-tap confirmation before points are awarded' },
+  { icon: 'shield',       label: 'Duplicate prevention — no accidental double-counts' },
+];
+
 /**
  * Wearable Sync — Coming Soon
  *
@@ -14,8 +31,6 @@ import { mflColors } from '../../constants/colors';
  */
 export default function WearablesRoute() {
   const insets = useSafeAreaInsets();
-  const isAndroid = Platform.OS === 'android';
-  const isIos = Platform.OS === 'ios';
 
   return (
     <ScreenScrollView>
@@ -56,25 +71,13 @@ export default function WearablesRoute() {
 
         {/* Upcoming capabilities */}
         <View className="w-full gap-3">
-          {[
-            {
-              icon: 'smartphone',
-              label: isAndroid
-                ? 'Health Connect (Android) — auto-detect workouts'
-                : isIos
-                  ? 'Apple HealthKit — auto-detect workouts'
-                  : 'Health Connect & Apple HealthKit support',
-            },
-            { icon: 'refresh-cw',  label: 'Automatic sync after each workout' },
-            { icon: 'check-circle', label: 'One-tap confirmation before points are awarded' },
-            { icon: 'shield',      label: 'Duplicate prevention — no accidental double-counts' },
-          ].map((item) => (
+          {UPCOMING_FEATURES.map((item) => (
             <View
               key={item.icon}
               className="flex-row items-center gap-3 rounded-xl px-4 py-3"
               style={{ backgroundColor: mflColors.card, borderWidth: 1, borderColor: mflColors.border }}
             >
-              <Feather name={item.icon as any} size={18} color={mflColors.blue} />
+              <Feather name={item.icon} size={18} color={mflColors.blue} />
               <AppText className="flex-1 text-sm text-foreground">{item.label}</AppText>
             </View>
           ))}

--- a/src/features/auth/utils/extract-api-error.ts
+++ b/src/features/auth/utils/extract-api-error.ts
@@ -2,9 +2,15 @@ import type { ApiRequestError } from '../types';
 
 /**
  * Extracts a user-facing error message from an API error.
- * Falls back to the provided fallback string when no message is available.
+ * Checks data.error, then data.message, then typed.message, then falls back.
+ * Uses || so empty strings fall through to the next option.
  */
 export function extractApiError(err: unknown, fallback: string): string {
-  const typed = err as ApiRequestError;
-  return typed?.response?.data?.error ?? typed?.message ?? fallback;
+  const typed = err as ApiRequestError & { message?: string };
+  return (
+    typed?.response?.data?.error ||
+    typed?.response?.data?.message ||
+    typed?.message ||
+    fallback
+  );
 }

--- a/src/features/wearables/components/connected-apps-screen.tsx
+++ b/src/features/wearables/components/connected-apps-screen.tsx
@@ -20,7 +20,7 @@ import {
   useConfirmWorkout,
   useRejectWorkout,
 } from '../hooks/use-pending-confirmations';
-import { extractApiError } from '../../../features/auth/utils/extract-api-error';
+import { extractApiError } from '../../auth/utils/extract-api-error';
 import { HealthConnectCard } from './health-connect-card';
 import { HealthKitCard } from './healthkit-card';
 import { PendingConfirmationCard } from './pending-confirmation-card';

--- a/src/features/wearables/components/connected-apps-screen.tsx
+++ b/src/features/wearables/components/connected-apps-screen.tsx
@@ -20,7 +20,7 @@ import {
   useConfirmWorkout,
   useRejectWorkout,
 } from '../hooks/use-pending-confirmations';
-import { getApiErrorMessage } from '../../leagues/utils/activity-config';
+import { extractApiError } from '../../../features/auth/utils/extract-api-error';
 import { HealthConnectCard } from './health-connect-card';
 import { HealthKitCard } from './healthkit-card';
 import { PendingConfirmationCard } from './pending-confirmation-card';
@@ -238,7 +238,7 @@ export function ConnectedAppsScreen() {
       } catch (error) {
         Alert.alert(
           'Could not confirm',
-          getApiErrorMessage(error, 'Failed to confirm activity.'),
+          extractApiError(error, 'Failed to confirm activity.'),
         );
       } finally {
         setConfirmingId(null);
@@ -255,7 +255,7 @@ export function ConnectedAppsScreen() {
       } catch (error) {
         Alert.alert(
           'Could not reject',
-          getApiErrorMessage(error, 'Failed to reject activity.'),
+          extractApiError(error, 'Failed to reject activity.'),
         );
       } finally {
         setRejectingId(null);


### PR DESCRIPTION
## Summary
Module 8 refactor — Wearables. Minimal changes needed — module was already well-structured. Addresses PR review blocker and nit.

## What was refactored

**`wearables.tsx`**
- Extracted inline icon array to module-level typed constant `UPCOMING_FEATURES: Array<{ icon: FeatherIconName; label: string }>`
- Added `FeatherIconName` type alias
- Removed `item.icon as any` cast
- Removed unused `isAndroid` and `isIos` variables

**`connected-apps-screen.tsx`**
- Replaced `getApiErrorMessage` with `extractApiError`
- Fixed import path: `'../../../features/auth/utils/extract-api-error'` → `'../../auth/utils/extract-api-error'`

**`src/features/auth/utils/extract-api-error.ts`**
- Fixed behavior to match original `getApiErrorMessage`:
  - Added missing `data.message` check
  - Changed `??` to `||` so empty strings fall through to next option
  - Order: `data.error || data.message || typed.message || fallback`

**No changes needed:**
- All hook, service, mapper, DTO, model files — already clean

## Files changed
- `src/app/(app)/wearables.tsx`
- `src/features/wearables/components/connected-apps-screen.tsx`
- `src/features/auth/utils/extract-api-error.ts`

## Tests
`npx tsc --noEmit` — zero errors across all Module 8 files.

## Risk
Low — `extractApiError` fix aligns behavior with original function. Import path fix is cosmetic.

## Part of
Part of #58