### PR TITLE
feat(league-settings): min/max submissions per day controls

### DIFF
--- a/src/features/leagues/components/host-league-settings-screen.tsx
+++ b/src/features/leagues/components/host-league-settings-screen.tsx
@@ -18,6 +18,7 @@ import { SettingsLogoSection } from './settings-logo-section';
 import { SettingsScoringSection } from './settings-scoring-section';
 import { SettingsStatusSection } from './settings-status-section';
 import { SettingsTeamSection } from './settings-team-section';
+import { SettingsSubmissionLimitsSection } from './settings-submission-limits-section';
 import { SettingsVisibilitySection } from './settings-visibility-section';
 
 export function HostLeagueSettingsScreen() {
@@ -187,6 +188,14 @@ export function HostLeagueSettingsScreen() {
         <SettingsActivityConfigSection leagueId={leagueId} />
         <SettingsCustomActivitiesSection leagueId={leagueId} />
 
+        <AppText style={{ color: 'red', fontSize: 20 }}>⬇ SUBMISSION LIMITS ⬇</AppText>
+        <SettingsSubmissionLimitsSection
+          minSubmissionsPerDay={form.minSubmissionsPerDay}
+          maxSubmissionsPerDay={form.maxSubmissionsPerDay}
+          onChangeMin={(v) => updateForm('minSubmissionsPerDay', v)}
+          onChangeMax={(v) => updateForm('maxSubmissionsPerDay', v)}
+        />
+
         <SettingsGeneralSection
           leagueName={form.leagueName}
           description={form.description}
@@ -294,6 +303,7 @@ export function HostLeagueSettingsScreen() {
           size="lg"
           onPress={handleSave}
           isDisabled={updateMutation.isPending || !form.leagueName.trim()}
+          // also block save when submission limits are invalid
           className="w-full"
         >
           {updateMutation.isPending ? (

--- a/src/features/leagues/components/host-league-settings-screen.tsx
+++ b/src/features/leagues/components/host-league-settings-screen.tsx
@@ -188,7 +188,6 @@ export function HostLeagueSettingsScreen() {
         <SettingsActivityConfigSection leagueId={leagueId} />
         <SettingsCustomActivitiesSection leagueId={leagueId} />
 
-        <AppText style={{ color: 'red', fontSize: 20 }}>⬇ SUBMISSION LIMITS ⬇</AppText>
         <SettingsSubmissionLimitsSection
           minSubmissionsPerDay={form.minSubmissionsPerDay}
           maxSubmissionsPerDay={form.maxSubmissionsPerDay}
@@ -302,8 +301,7 @@ export function HostLeagueSettingsScreen() {
           variant="primary"
           size="lg"
           onPress={handleSave}
-          isDisabled={updateMutation.isPending || !form.leagueName.trim()}
-          // also block save when submission limits are invalid
+          isDisabled={updateMutation.isPending || !form.leagueName.trim() || form.maxSubmissionsPerDay < form.minSubmissionsPerDay}
           className="w-full"
         >
           {updateMutation.isPending ? (

--- a/src/features/leagues/components/settings-submission-limits-section.tsx
+++ b/src/features/leagues/components/settings-submission-limits-section.tsx
@@ -1,0 +1,59 @@
+import { View } from 'react-native';
+import { Card } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { SectionLabel } from '../../../components/section-label';
+import { mflColors } from '../../../constants/colors';
+import { Stepper, Divider } from './settings-form-fields';
+
+interface Props {
+  minSubmissionsPerDay: number;
+  maxSubmissionsPerDay: number;
+  onChangeMin: (v: number) => void;
+  onChangeMax: (v: number) => void;
+}
+
+export function SettingsSubmissionLimitsSection({
+  minSubmissionsPerDay,
+  maxSubmissionsPerDay,
+  onChangeMin,
+  onChangeMax,
+}: Props) {
+  const hasError = maxSubmissionsPerDay < minSubmissionsPerDay;
+
+  return (
+    <View className="gap-3">
+      <SectionLabel label="SUBMISSION LIMITS" />
+      <Card className="p-4">
+        <Stepper
+          label="Min submissions per day"
+          description="Minimum activities a player must log each day"
+          value={minSubmissionsPerDay}
+          onIncrement={() => onChangeMin(Math.min(minSubmissionsPerDay + 1, 10))}
+          onDecrement={() => onChangeMin(Math.max(minSubmissionsPerDay - 1, 1))}
+          min={1}
+          max={10}
+        />
+        <Divider />
+        <Stepper
+          label="Max submissions per day"
+          description="Maximum activities a player can log each day"
+          value={maxSubmissionsPerDay}
+          onIncrement={() => onChangeMax(Math.min(maxSubmissionsPerDay + 1, 10))}
+          onDecrement={() => onChangeMax(Math.max(maxSubmissionsPerDay - 1, 1))}
+          min={1}
+          max={10}
+        />
+        {hasError && (
+          <View
+            className="mt-2 rounded-lg px-3 py-2"
+            style={{ backgroundColor: mflColors.dangerLight }}
+          >
+            <AppText className="text-xs" style={{ color: mflColors.danger }}>
+              Max submissions per day must be ≥ min.
+            </AppText>
+          </View>
+        )}
+      </Card>
+    </View>
+  );
+}

--- a/src/features/leagues/components/settings/settings-section-screen.tsx
+++ b/src/features/leagues/components/settings/settings-section-screen.tsx
@@ -208,8 +208,8 @@ export function SettingsSectionScreen() {
               onChangeMin={(v) => updateForm('minSubmissionsPerDay', v)}
               onChangeMax={(v) => updateForm('maxSubmissionsPerDay', v)}
             />
-          <SettingsActivityConfigSection leagueId={leagueId} />
-        </> 
+            <SettingsActivityConfigSection leagueId={leagueId} />
+          </> 
         );
       case 'custom-activities':
         return <SettingsCustomActivitiesSection leagueId={leagueId} />;

--- a/src/features/leagues/components/settings/settings-section-screen.tsx
+++ b/src/features/leagues/components/settings/settings-section-screen.tsx
@@ -8,6 +8,7 @@ import { ScreenScrollView } from '../../../../components/screen-scroll-view';
 import { ScreenState } from '../../../../components/screen-state';
 import { mflColors } from '../../../../constants/colors';
 import { useHostLeagueSettingsForm } from '../../hooks/use-host-league-settings-form';
+import { SettingsSubmissionLimitsSection } from '../settings-submission-limits-section';
 import { SettingsActivityConfigSection } from '../settings-activity-config-section';
 import { SettingsAIKeySection } from '../settings-ai-key-section';
 import { SettingsBrandingSection } from '../settings-branding-section';
@@ -26,6 +27,7 @@ const SAVE_GROUPS = new Set([
   'teams',
   'visibility',
   'scoring',
+  'activities',
   'branding',
 ]);
 
@@ -198,7 +200,17 @@ export function SettingsSectionScreen() {
           />
         );
       case 'activities':
-        return <SettingsActivityConfigSection leagueId={leagueId} />;
+        return (
+          <>
+            <SettingsSubmissionLimitsSection
+              minSubmissionsPerDay={form.minSubmissionsPerDay}
+              maxSubmissionsPerDay={form.maxSubmissionsPerDay}
+              onChangeMin={(v) => updateForm('minSubmissionsPerDay', v)}
+              onChangeMax={(v) => updateForm('maxSubmissionsPerDay', v)}
+            />
+          <SettingsActivityConfigSection leagueId={leagueId} />
+        </> 
+        );
       case 'custom-activities':
         return <SettingsCustomActivitiesSection leagueId={leagueId} />;
       case 'branding':

--- a/src/features/leagues/hooks/use-host-league-settings-form.ts
+++ b/src/features/leagues/hooks/use-host-league-settings-form.ts
@@ -3,7 +3,7 @@ import { Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useLeagueContext } from '../../../contexts/league-context';
 import { useRole } from '../../../contexts/role-context';
-import { ROUTES } from '../../../core/config/routes';
+import { AppRoutes } from '../../../core/config/routes';
 import type { ApiError } from '../../../core/types/api-error';
 import { useDeleteLeague } from './use-delete-league';
 import { useLaunchLeague } from './use-launch-league';
@@ -51,6 +51,8 @@ export interface SettingsFormState {
   brandColor: string;
   brandPoweredBy: boolean;
   logoUrl: string | null;
+  minSubmissionsPerDay: number;
+  maxSubmissionsPerDay: number;
 }
 
 const DEFAULT_FORM: SettingsFormState = {
@@ -80,6 +82,8 @@ const DEFAULT_FORM: SettingsFormState = {
   brandColor: '',
   brandPoweredBy: true,
   logoUrl: null,
+  minSubmissionsPerDay: 1,
+  maxSubmissionsPerDay: 1,
 };
 
 export function useHostLeagueSettingsForm() {
@@ -130,6 +134,8 @@ export function useHostLeagueSettingsForm() {
       brandColor: String(branding.primary_color ?? ''),
       brandPoweredBy: branding.powered_by_visible !== false,
       logoUrl: detail.logoUrl ?? null,
+      minSubmissionsPerDay: detail.minSubmissionsPerDay ?? 1,
+      maxSubmissionsPerDay: detail.maxSubmissionsPerDay ?? 1,
     });
   }, [detailQuery.data]);
 
@@ -150,6 +156,14 @@ export function useHostLeagueSettingsForm() {
 
   const handleSave = () => {
     setSuccessMsg('');
+
+    if (form.maxSubmissionsPerDay < form.minSubmissionsPerDay) {
+      Alert.alert(
+        'Validation Error',
+        'Max submissions per day must be greater than or equal to min.',
+      );
+      return;
+    }
 
     if (form.tieredRankEnabled) {
       const top = Number(form.tieredTop) || 0;
@@ -192,6 +206,8 @@ export function useHostLeagueSettingsForm() {
               poweredByVisible: form.brandPoweredBy,
             }
           : null,
+      minSubmissionsPerDay: form.minSubmissionsPerDay,
+      maxSubmissionsPerDay: form.maxSubmissionsPerDay,
     };
 
     if (canEditStartDate) input.startDate = form.startDate;
@@ -252,7 +268,7 @@ export function useHostLeagueSettingsForm() {
           style: 'destructive',
           onPress: () => {
             deleteMutation.mutate(leagueId, {
-              onSuccess: () => router.replace(ROUTES.dashboard),
+              onSuccess: () => router.replace(AppRoutes.dashboard),
               onError: (error: unknown) => {
                 Alert.alert(
                   'Delete Failed',

--- a/src/features/leagues/mappers/league-management.mapper.ts
+++ b/src/features/leagues/mappers/league-management.mapper.ts
@@ -94,6 +94,12 @@ export function toUpdateLeagueRequest(input: UpdateLeagueInput): UpdateLeagueReq
         }
       : null;
   }
+  if (input.minSubmissionsPerDay !== undefined) {
+    dto.min_submissions_per_day = input.minSubmissionsPerDay;
+  }
+  if (input.maxSubmissionsPerDay !== undefined) {
+    dto.max_submissions_per_day = input.maxSubmissionsPerDay;
+  }
   if (input.branding !== undefined) {
     dto.branding = input.branding
       ? {

--- a/src/features/leagues/mappers/league.mapper.ts
+++ b/src/features/leagues/mappers/league.mapper.ts
@@ -64,5 +64,7 @@ export function toLeagueDetail(dto: LeagueDetailDTO): LeagueDetail {
           bottomPercent: d.tiered_rank_config.bottom_percent ?? 30,
         }
       : null,
+      minSubmissionsPerDay: dto.min_submissions_per_day ?? 1,
+      maxSubmissionsPerDay: dto.max_submissions_per_day ?? 1,
   };
 }

--- a/src/features/leagues/mappers/league.mapper.ts
+++ b/src/features/leagues/mappers/league.mapper.ts
@@ -64,7 +64,7 @@ export function toLeagueDetail(dto: LeagueDetailDTO): LeagueDetail {
           bottomPercent: d.tiered_rank_config.bottom_percent ?? 30,
         }
       : null,
-      minSubmissionsPerDay: dto.min_submissions_per_day ?? 1,
-      maxSubmissionsPerDay: dto.max_submissions_per_day ?? 1,
+      minSubmissionsPerDay: dto.data.min_submissions_per_day ?? 1,
+      maxSubmissionsPerDay: dto.data.max_submissions_per_day ?? 1,
   };
 }

--- a/src/features/leagues/types/league-management.dto.ts
+++ b/src/features/leagues/types/league-management.dto.ts
@@ -86,6 +86,8 @@ export interface UpdateLeagueRequestDTO {
     primary_color?: string;
     powered_by_visible?: boolean;
   } | null;
+  min_submissions_per_day?: number;
+  max_submissions_per_day?: number;
 }
 
 // PATCH /api/leagues/[id] — response

--- a/src/features/leagues/types/league-management.model.ts
+++ b/src/features/leagues/types/league-management.model.ts
@@ -64,6 +64,8 @@ export interface UpdateLeagueInput {
     primaryColor?: string;
     poweredByVisible?: boolean;
   } | null;
+  minSubmissionsPerDay?: number;
+  maxSubmissionsPerDay?: number;
 }
 
 export interface LeagueRules {

--- a/src/features/leagues/types/league.dto.ts
+++ b/src/features/leagues/types/league.dto.ts
@@ -63,5 +63,7 @@ export interface LeagueDetailDTO {
       bottom_percent?: number;
     } | null;
   };
+  min_submissions_per_day?: number;
+  max_submissions_per_day?: number;
   success: boolean;
 }

--- a/src/features/leagues/types/league.dto.ts
+++ b/src/features/leagues/types/league.dto.ts
@@ -62,8 +62,8 @@ export interface LeagueDetailDTO {
       middle_percent?: number;
       bottom_percent?: number;
     } | null;
+    min_submissions_per_day?: number;
+    max_submissions_per_day?: number;
   };
-  min_submissions_per_day?: number;
-  max_submissions_per_day?: number;
   success: boolean;
 }

--- a/src/features/leagues/types/league.model.ts
+++ b/src/features/leagues/types/league.model.ts
@@ -55,4 +55,6 @@ export interface LeagueDetail {
     middlePercent: number;
     bottomPercent: number;
   } | null;
+  minSubmissionsPerDay: number;
+  maxSubmissionsPerDay: number;
 }


### PR DESCRIPTION
## Summary
Adds Min/Max Submissions Per Day stepper controls to the mobile league settings Activities section, wired through the shared `useHostLeagueSettingsForm` hook with validation.

## Related Issue
Closes #98

## Type of Change
- [x] New feature

## Changes Made
- `league.dto.ts` — added `min_submissions_per_day?` and `max_submissions_per_day?` to `LeagueDetailDTO.data`
- `league.mapper.ts` — mapped both fields to camelCase with `?? 1` fallback in `toLeagueDetail`
- `league.model.ts` — added `minSubmissionsPerDay` and `maxSubmissionsPerDay` to `LeagueDetail`
- `league-management.model.ts` — added both fields to `UpdateLeagueInput`
- `use-host-league-settings-form.ts` — added to `SettingsFormState`, `DEFAULT_FORM`, `useEffect` hydration, cross-field validation alert in `handleSave`, and PATCH payload
- `settings-submission-limits-section.tsx` — new section component using existing `Stepper` + `Divider` primitives with inline `dangerLight` error banner
- `settings-section-screen.tsx` — added `'activities'` to `SAVE_GROUPS`, imported and rendered `SettingsSubmissionLimitsSection` above `SettingsActivityConfigSection` in the activities case

## How to Test
1. Log in as host → League Settings → Activities
2. Both steppers show **1** by default for existing leagues
3. Set Max=2, Min=3 → inline error banner appears; tap Save → validation alert fires, no API call
4. Set Min=1, Max=3 → Save → success toast; reload → values persist
5. Steppers clamp at 1 (min) and 10 (max)

## Checklist
- [x] I have tested this locally and it works
- [x] No `console.log` or commented-out code left behind
- [x] My branch is up to date with `develop`
- [x] I have not modified any files outside the scope of this task