### PR TITLE
fix(leaderboard): prevent RR column clipping on narrow screens

### DIFF
--- a/src/features/leaderboard/components/ranking-cards.tsx
+++ b/src/features/leaderboard/components/ranking-cards.tsx
@@ -32,9 +32,9 @@ export function TeamRankingCard({
       className="py-2 px-3"
       style={team.rank <= 3 ? { borderWidth: 1, borderColor: mflColors.brandLight } : undefined}
     >
-      <View className="flex-row items-center justify-between gap-3">
+      <View className="flex-row items-center justify-between gap-2">
         {/* Left: Rank, Logo, Team Name */}
-        <View className="flex-row items-center gap-2.5 flex-1">
+        <View className="flex-row items-center gap-2 flex-1" style={{ minWidth: 0 }}>
           <RankBadge rank={team.rank} tier={team.rank_tier} band={team.rank_band} />
 
           <View
@@ -65,18 +65,18 @@ export function TeamRankingCard({
         </View>
 
         {/* Right: Points, Logs, RR */}
-        <View className="items-end">
+        <View className="items-end" style={{ flexShrink: 0 }}>
           <AppText className="text-base font-bold" style={{ color: mflColors.brand }}>
             {formatNumber(team.total_points)} pts
           </AppText>
-          <View className="flex-row items-center gap-1.5 mt-0.5">
-            <AppText className="text-[10px] text-muted">
+          <View className="flex-row items-center gap-1 mt-0.5">
+            <AppText className="text-[10px] text-muted" numberOfLines={1}>
               {team.submission_count} logs
             </AppText>
             {showAvgRR && (
               <>
                 <AppText className="text-[10px] text-muted">·</AppText>
-                <AppText className="text-[10px] font-semibold" style={{ color: mflColors.amber }}>
+                <AppText className="text-[9px] font-semibold" style={{ color: mflColors.amber }} numberOfLines={1}>
                   RR {team.avg_rr.toFixed(2)}
                 </AppText>
               </>
@@ -111,10 +111,10 @@ export function IndividualRankingCard({
   showAvgRR: boolean;
 }) {
   return (
-    <Card className="py-2 px-3">
-      <View className="flex-row items-center justify-between gap-3">
+    <Card className="py-2 px-2.5">
+      <View className="flex-row items-center justify-between gap-2">
         {/* Left: Rank, Avatar, Player Name */}
-        <View className="flex-row items-center gap-2.5 flex-1">
+        <View className="flex-row items-center gap-2 flex-1" style={{ minWidth: 0 }}>
           <RankBadge rank={player.rank} tier={player.rank_tier} band={player.rank_band} />
 
           <Avatar size="sm" alt={player.username} style={{ width: 32, height: 32 }}>
@@ -141,18 +141,18 @@ export function IndividualRankingCard({
         </View>
 
         {/* Right: Points, Logs, RR */}
-        <View className="items-end">
+        <View className="items-end" style={{ flexShrink: 0 }}>
           <AppText className="text-base font-bold" style={{ color: mflColors.brand }}>
             {formatNumber(player.points)} pts
           </AppText>
-          <View className="flex-row items-center gap-1.5 mt-0.5">
-            <AppText className="text-[10px] text-muted">
+          <View className="flex-row items-center gap-1 mt-0.5">
+            <AppText className="text-[10px] text-muted" numberOfLines={1}>
               {player.submission_count} logs
             </AppText>
             {showAvgRR && (
               <>
                 <AppText className="text-[10px] text-muted">·</AppText>
-                <AppText className="text-[10px] font-semibold" style={{ color: mflColors.amber }}>
+                <AppText className="text-[9px] font-semibold" style={{ color: mflColors.amber }} numberOfLines={1}>
                   RR {player.avg_rr.toFixed(2)}
                 </AppText>
               </>


### PR DESCRIPTION
Partial fix for #134 

## What changed
- RR values (and points/logs) on the team and individual leaderboard cards were getting clipped on screens 320–360px wide. - Root cause: the left (rank/avatar/name) flex block had no minWidth: 0, so it refused to shrink below content size, pushing the right-side stats block past the visible edge. The right block also had no flexShrink: 0, so the rightmost item (RR text) was the first to get clipped.
- Fix: added minWidth: 0 to the left flex container so it can compress, added flexShrink: 0 to the right stats block so it always renders at full intrinsic width, capped RR/log text to numberOfLines={1}, dropped RR font from 10px→9px, and tightened gaps/padding slightly across both card types.

## Files changed

src/features/leaderboard/components/ranking-cards.tsx

## Tested

 - Verified on 320px width simulator — RR fully visible, no clipping
 - Verified on 360px width simulator
 - No horizontal scroll introduced
 - Verified team leaderboard cards (RankingCard) unaffected visually on normal-width devices
 - Verified individual leaderboard cards on normal-width devices
 - Long team/player names still truncate correctly (no layout break)