### PR TITLE
feat: add weight loss challenge mobile parity

### DIFF
--- a/src/app/(app)/challenges/weight-log.tsx
+++ b/src/app/(app)/challenges/weight-log.tsx
@@ -1,0 +1,28 @@
+// Removed React import
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { ScreenScrollView } from '../../../components/screen-scroll-view';
+import { WeightLogScreen } from '../../../features/challenges/components/weight-log-screen';
+import { useLeagueContext } from '../../../contexts/league-context';
+import { ScreenState } from '../../../components/screen-state';
+
+export default function WeightLogRoute() {
+  const { challengeId } = useLocalSearchParams<{ challengeId: string }>();
+  const { activeLeague } = useLeagueContext();
+  const leagueId = activeLeague?.leagueId ?? '';
+
+  if (!leagueId) {
+    return (
+      <ScreenScrollView>
+        <Stack.Screen options={{ title: 'Log Weight' }} />
+        <ScreenState screen="weight-log" state="empty" message="Select a league first" />
+      </ScreenScrollView>
+    );
+  }
+
+  return (
+    <ScreenScrollView>
+      <Stack.Screen options={{ title: 'Log Weight' }} />
+      <WeightLogScreen leagueId={leagueId} challengeId={challengeId ?? ''} />
+    </ScreenScrollView>
+  );
+}

--- a/src/features/challenges/components/challenge-action-bar.tsx
+++ b/src/features/challenges/components/challenge-action-bar.tsx
@@ -1,5 +1,6 @@
 import { View } from 'react-native';
 import { Button } from 'heroui-native';
+import { useRouter } from 'expo-router';
 
 import { AppText } from '../../../components/app-text';
 import { mflColors } from '../../../constants/colors';
@@ -11,8 +12,28 @@ interface ChallengeActionBarProps {
 }
 
 export function ChallengeActionBar({ challenge, onSubmitProof }: ChallengeActionBarProps) {
+  const router = useRouter();
+
   if (challenge.challengeType === 'tournament') {
     return null;
+  }
+
+  if (challenge.challengeType === 'weight_loss') {
+    return (
+      <Button
+        variant="primary"
+        size="lg"
+        onPress={() => {
+          router.push({
+            pathname: '/(app)/challenges/weight-log' as any,
+            params: { challengeId: challenge.challengeId },
+          });
+        }}
+        className="w-full"
+      >
+        <Button.Label>Log Weight</Button.Label>
+      </Button>
+    );
   }
 
   const myStatus = challenge.mySubmission?.status as string | undefined;

--- a/src/features/challenges/components/challenge-config-form-card.tsx
+++ b/src/features/challenges/components/challenge-config-form-card.tsx
@@ -9,6 +9,7 @@ import { mflColors } from '../../../constants/colors';
 import type { ChallengeConfigForm, PickedChallengeDocument } from '../types/challenge-config';
 import { CHALLENGE_TYPES } from '../utils/challenge-config-utils';
 import { WeightLossTierConfig } from './weight-loss-tier-config';
+import { WeightLossTier } from '../types/challenge.model';
 
 const inputStyle = {
   backgroundColor: mflColors.card,
@@ -209,7 +210,7 @@ export function ChallengeConfigFormCard({
             onAddTier={() => {
               const prevTiers = form.config?.tiers || [];
               const highestThreshold =
-                prevTiers.length > 0 ? Math.max(...prevTiers.map((t: any) => t.thresholdPercent)) : 0;
+                prevTiers.length > 0 ? Math.max(...prevTiers.map((t) => t.thresholdPercent)) : 0;
               onChange({
                 config: {
                   ...form.config,
@@ -222,14 +223,15 @@ export function ChallengeConfigFormCard({
               onChange({
                 config: {
                   ...form.config,
-                  tiers: prevTiers.filter((_: any, i: number) => i !== index),
+                  tiers: prevTiers.filter((_, i) => i !== index),
                 },
               });
             }}
             onUpdateTier={(index, field, value) => {
               const prevTiers = form.config?.tiers || [];
-              const updated = [...prevTiers];
-              updated[index] = { ...updated[index], [field]: value };
+              const updated = prevTiers.map((tier, i) =>
+                i === index ? ({ ...tier, [field]: value } as WeightLossTier) : tier,
+              );
               onChange({
                 config: { ...form.config, tiers: updated },
               });

--- a/src/features/challenges/components/challenge-config-form-card.tsx
+++ b/src/features/challenges/components/challenge-config-form-card.tsx
@@ -8,6 +8,7 @@ import { SectionLabel } from '../../../components/section-label';
 import { mflColors } from '../../../constants/colors';
 import type { ChallengeConfigForm, PickedChallengeDocument } from '../types/challenge-config';
 import { CHALLENGE_TYPES } from '../utils/challenge-config-utils';
+import { WeightLossTierConfig } from './weight-loss-tier-config';
 
 const inputStyle = {
   backgroundColor: mflColors.card,
@@ -196,6 +197,45 @@ export function ChallengeConfigFormCard({
               </AppText>
             </View>
           </Pressable>
+        ) : null}
+
+        {form.challengeType === 'weight_loss' ? (
+          <WeightLossTierConfig
+            durationDays={form.config?.durationDays}
+            onDurationChange={(days) =>
+              onChange({ config: { ...form.config, durationDays: days } })
+            }
+            tiers={form.config?.tiers || []}
+            onAddTier={() => {
+              const prevTiers = form.config?.tiers || [];
+              const highestThreshold =
+                prevTiers.length > 0 ? Math.max(...prevTiers.map((t: any) => t.thresholdPercent)) : 0;
+              onChange({
+                config: {
+                  ...form.config,
+                  tiers: [...prevTiers, { thresholdPercent: highestThreshold + 1, points: 0 }],
+                },
+              });
+            }}
+            onRemoveTier={(index) => {
+              const prevTiers = form.config?.tiers || [];
+              onChange({
+                config: {
+                  ...form.config,
+                  tiers: prevTiers.filter((_: any, i: number) => i !== index),
+                },
+              });
+            }}
+            onUpdateTier={(index, field, value) => {
+              const prevTiers = form.config?.tiers || [];
+              const updated = [...prevTiers];
+              updated[index] = { ...updated[index], [field]: value };
+              onChange({
+                config: { ...form.config, tiers: updated },
+              });
+            }}
+            isValid={true}
+          />
         ) : null}
 
         <View className="flex-row gap-3">

--- a/src/features/challenges/components/challenge-detail-screen.tsx
+++ b/src/features/challenges/components/challenge-detail-screen.tsx
@@ -15,13 +15,13 @@ import { ChallengeLeaderboardList } from './challenge-leaderboard-list';
 import { ChallengeFixturesList } from './challenge-fixtures-list';
 import { ChallengeStandingsTable } from './challenge-standings-table';
 import { ChallengeActionBar } from './challenge-action-bar';
+import { WeightLossHostResults } from './weight-loss-host-results';
+import { useWeightLossLogHost } from '../hooks/use-weight-loss-log';
 
 const STANDARD_TABS = ['Submissions', 'Leaderboard'] as const;
 const TOURNAMENT_TABS = ['Fixtures', 'Standings'] as const;
 
-type StandardTab = (typeof STANDARD_TABS)[number];
-type TournamentTab = (typeof TOURNAMENT_TABS)[number];
-type Tab = StandardTab | TournamentTab;
+// Types removed
 
 export function ChallengeDetailScreen() {
   const router = useRouter();
@@ -38,11 +38,22 @@ export function ChallengeDetailScreen() {
     refetchAll,
   } = useChallengeDetail(leagueId, challengeId ?? '');
 
-  const [activeTab, setActiveTab] = useState<Tab>(
-    isTournament ? 'Fixtures' : 'Submissions',
-  );
+  const isWeightLoss = challenge?.challengeType === 'weight_loss';
+  const isHost = activeLeague?.isHost ?? false;
 
-  const tabs = isTournament ? TOURNAMENT_TABS : STANDARD_TABS;
+  const hostResultsQuery = useWeightLossLogHost(leagueId, challengeId ?? '');
+
+  // Define tabs dynamically based on challenge type and role
+  let tabs: readonly string[] = STANDARD_TABS;
+  if (isTournament) {
+    tabs = TOURNAMENT_TABS;
+  } else if (isWeightLoss) {
+    tabs = isHost ? ['Results', 'Leaderboard'] : ['Leaderboard'];
+  }
+
+  const [activeTab, setActiveTab] = useState<string>(
+    isTournament ? 'Fixtures' : isWeightLoss ? (isHost ? 'Results' : 'Leaderboard') : 'Submissions',
+  );
 
   if (!activeLeague) {
     return (
@@ -80,7 +91,7 @@ export function ChallengeDetailScreen() {
 
         {/* Tabs */}
         <Animated.View entering={FadeInDown.duration(300).delay(120)}>
-          <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as Tab)}>
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
             <Tabs.List>
               {tabs.map((tab) => (
                 <Tabs.Trigger key={tab} value={tab}>
@@ -93,7 +104,9 @@ export function ChallengeDetailScreen() {
 
         {/* Tab Content */}
         <Animated.View entering={FadeInDown.duration(300).delay(200)}>
-          {isTournament ? (
+          {activeTab === 'Results' && isWeightLoss && isHost ? (
+            <WeightLossHostResults participants={hostResultsQuery.data || []} />
+          ) : isTournament ? (
             activeTab === 'Fixtures' ? (
               <ChallengeFixturesList
                 matches={matches.data}

--- a/src/features/challenges/components/challenge-detail-screen.tsx
+++ b/src/features/challenges/components/challenge-detail-screen.tsx
@@ -21,7 +21,10 @@ import { useWeightLossLogHost } from '../hooks/use-weight-loss-log';
 const STANDARD_TABS = ['Submissions', 'Leaderboard'] as const;
 const TOURNAMENT_TABS = ['Fixtures', 'Standings'] as const;
 
-// Types removed
+type StandardTab = (typeof STANDARD_TABS)[number];
+type TournamentTab = (typeof TOURNAMENT_TABS)[number];
+type WeightLossTab = 'Results' | 'Leaderboard';
+type Tab = StandardTab | TournamentTab | WeightLossTab;
 
 export function ChallengeDetailScreen() {
   const router = useRouter();
@@ -41,17 +44,17 @@ export function ChallengeDetailScreen() {
   const isWeightLoss = challenge?.challengeType === 'weight_loss';
   const isHost = activeLeague?.isHost ?? false;
 
-  const hostResultsQuery = useWeightLossLogHost(leagueId, challengeId ?? '');
+  const hostResultsQuery = useWeightLossLogHost(leagueId, challengeId ?? '', isWeightLoss && isHost);
 
   // Define tabs dynamically based on challenge type and role
-  let tabs: readonly string[] = STANDARD_TABS;
+  let tabs: readonly Tab[] = STANDARD_TABS;
   if (isTournament) {
     tabs = TOURNAMENT_TABS;
   } else if (isWeightLoss) {
     tabs = isHost ? ['Results', 'Leaderboard'] : ['Leaderboard'];
   }
 
-  const [activeTab, setActiveTab] = useState<string>(
+  const [activeTab, setActiveTab] = useState<Tab>(
     isTournament ? 'Fixtures' : isWeightLoss ? (isHost ? 'Results' : 'Leaderboard') : 'Submissions',
   );
 
@@ -91,7 +94,7 @@ export function ChallengeDetailScreen() {
 
         {/* Tabs */}
         <Animated.View entering={FadeInDown.duration(300).delay(120)}>
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as Tab)}>
             <Tabs.List>
               {tabs.map((tab) => (
                 <Tabs.Trigger key={tab} value={tab}>

--- a/src/features/challenges/components/weight-log-screen.tsx
+++ b/src/features/challenges/components/weight-log-screen.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { View, TextInput, Alert } from 'react-native';
+import { Button, Spinner } from 'heroui-native';
+import { AppText } from '../../../components/app-text';
+import { SectionLabel } from '../../../components/section-label';
+import { mflColors } from '../../../constants/colors';
+import { useWeightLossLogPlayer, useSubmitWeightLog } from '../hooks/use-weight-loss-log';
+import { WeightLossPredictionBanner } from './weight-loss-prediction-banner';
+import { WeightLossResults } from './weight-loss-results';
+import { reportError } from '../../../core/utils/report-error';
+
+interface WeightLogScreenProps {
+  leagueId: string;
+  challengeId: string;
+  onBack?: () => void;
+}
+
+export function WeightLogScreen({ leagueId, challengeId }: WeightLogScreenProps) {
+  const { data: logData, isLoading } = useWeightLossLogPlayer(leagueId, challengeId);
+  const submitLog = useSubmitWeightLog(leagueId, challengeId);
+  const [weightInput, setWeightInput] = useState('');
+
+  const hasStartLog = logData?.logs?.some((l) => l.logType === 'start');
+  const hasEndLog = logData?.logs?.some((l) => l.logType === 'end');
+
+  const handleLogWeight = async (logType: 'start' | 'progress' | 'end') => {
+    if (!weightInput.trim() || isNaN(Number(weightInput))) {
+      Alert.alert('Invalid Weight', 'Please enter a valid number.');
+      return;
+    }
+
+    try {
+      await submitLog.mutateAsync({
+        logType,
+        weight: Number(weightInput),
+      });
+      setWeightInput('');
+      Alert.alert('Success', 'Weight logged successfully!');
+    } catch (err: any) {
+      if (__DEV__) {
+        reportError(err);
+      }
+      Alert.alert('Error', err.message || 'Failed to log weight.');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center p-8">
+        <Spinner size="lg" />
+      </View>
+    );
+  }
+
+  return (
+    <View className="gap-6 p-4">
+      {logData?.prediction && (
+        <WeightLossPredictionBanner prediction={logData.prediction} />
+      )}
+
+      {logData?.result ? (
+        <WeightLossResults result={logData.result} />
+      ) : (
+        <View className="gap-4">
+          <SectionLabel label="Log Your Weight" />
+          <View className="p-4 rounded-xl border border-border bg-card gap-4">
+            <View className="gap-2">
+              <AppText className="text-xs font-semibold text-muted uppercase">Weight</AppText>
+              <TextInput
+                style={{
+                  backgroundColor: mflColors.card,
+                  borderWidth: 1,
+                  borderColor: mflColors.border,
+                  borderRadius: 12,
+                  paddingHorizontal: 14,
+                  paddingVertical: 11,
+                  fontSize: 15,
+                  color: mflColors.text,
+                }}
+                value={weightInput}
+                onChangeText={setWeightInput}
+                placeholder="Enter weight"
+                placeholderTextColor={mflColors.textMuted}
+                keyboardType="numeric"
+              />
+            </View>
+
+            <View className="gap-2 flex-row">
+              {!hasStartLog && (
+                <Button
+                  variant="primary"
+                  className="flex-1"
+                  onPress={() => handleLogWeight('start')}
+                  isDisabled={submitLog.isPending}
+                >
+                  {submitLog.isPending ? <Spinner size="sm" /> : <Button.Label>Log Start</Button.Label>}
+                </Button>
+              )}
+
+              {hasStartLog && !hasEndLog && (
+                <>
+                  <Button
+                    variant="secondary"
+                    className="flex-1"
+                    onPress={() => handleLogWeight('progress')}
+                    isDisabled={submitLog.isPending}
+                  >
+                    {submitLog.isPending ? <Spinner size="sm" /> : <Button.Label>Log Progress</Button.Label>}
+                  </Button>
+                  <Button
+                    variant="primary"
+                    className="flex-1"
+                    onPress={() => handleLogWeight('end')}
+                    isDisabled={submitLog.isPending}
+                  >
+                    {submitLog.isPending ? <Spinner size="sm" /> : <Button.Label>Log End</Button.Label>}
+                  </Button>
+                </>
+              )}
+            </View>
+          </View>
+        </View>
+      )}
+
+      {logData?.logs && logData.logs.length > 0 && (
+        <View className="gap-3 mt-4">
+          <SectionLabel label="History" />
+          <View className="rounded-xl border border-border bg-card overflow-hidden">
+            {logData.logs.map((log, i) => (
+              <View
+                key={log.id}
+                className={`flex-row justify-between p-4 ${
+                  i < logData.logs.length - 1 ? 'border-b border-border' : ''
+                }`}
+              >
+                <AppText className="text-sm font-semibold text-foreground capitalize">
+                  {log.logType} Weight
+                </AppText>
+                <AppText className="text-sm font-bold text-foreground">
+                  {log.weight}
+                </AppText>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/features/challenges/components/weight-log-screen.tsx
+++ b/src/features/challenges/components/weight-log-screen.tsx
@@ -24,23 +24,25 @@ export function WeightLogScreen({ leagueId, challengeId }: WeightLogScreenProps)
   const hasEndLog = logData?.logs?.some((l) => l.logType === 'end');
 
   const handleLogWeight = async (logType: 'start' | 'progress' | 'end') => {
-    if (!weightInput.trim() || isNaN(Number(weightInput))) {
-      Alert.alert('Invalid Weight', 'Please enter a valid number.');
+    const weight = Number(weightInput);
+    if (!weightInput.trim() || isNaN(weight) || weight <= 0 || weight > 1000) {
+      Alert.alert('Invalid Weight', 'Please enter a weight between 1 and 1000 lbs.');
       return;
     }
 
     try {
       await submitLog.mutateAsync({
         logType,
-        weight: Number(weightInput),
+        weight,
       });
       setWeightInput('');
       Alert.alert('Success', 'Weight logged successfully!');
-    } catch (err: any) {
+    } catch (err) {
       if (__DEV__) {
         reportError(err);
       }
-      Alert.alert('Error', err.message || 'Failed to log weight.');
+      const message = err instanceof Error ? err.message : 'Failed to log weight.';
+      Alert.alert('Error', message);
     }
   };
 

--- a/src/features/challenges/components/weight-loss-host-results.tsx
+++ b/src/features/challenges/components/weight-loss-host-results.tsx
@@ -1,0 +1,53 @@
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import type { WeightLogHostParticipant } from '../types/challenge.model';
+
+interface WeightLossHostResultsProps {
+  participants: WeightLogHostParticipant[];
+}
+
+export function WeightLossHostResults({ participants }: WeightLossHostResultsProps) {
+  if (participants.length === 0) {
+    return (
+      <View className="p-4 items-center justify-center border border-border rounded-xl bg-card">
+        <AppText className="text-sm text-muted">No participants have logged weights yet.</AppText>
+      </View>
+    );
+  }
+
+  return (
+    <View className="border border-border rounded-xl overflow-hidden bg-card">
+      <View className="flex-row p-3 border-b border-border bg-card-secondary">
+        <AppText className="flex-1 text-xs font-bold text-muted uppercase">Player</AppText>
+        <AppText className="w-16 text-xs font-bold text-muted uppercase text-center">Start</AppText>
+        <AppText className="w-16 text-xs font-bold text-muted uppercase text-center">End</AppText>
+        <AppText className="w-16 text-xs font-bold text-muted uppercase text-center">% Loss</AppText>
+        <AppText className="w-12 text-xs font-bold text-muted uppercase text-right">Pts</AppText>
+      </View>
+      {participants.map((p, i) => (
+        <View
+          key={p.leagueMemberId}
+          className={`flex-row p-3 items-center ${
+            i < participants.length - 1 ? 'border-b border-border' : ''
+          }`}
+        >
+          <AppText className="flex-1 text-sm font-semibold text-foreground" numberOfLines={1}>
+            {p.username}
+          </AppText>
+          <AppText className="w-16 text-sm text-muted text-center">
+            {p.startWeight ? p.startWeight.toFixed(1) : '-'}
+          </AppText>
+          <AppText className="w-16 text-sm text-muted text-center">
+            {p.endWeight ? p.endWeight.toFixed(1) : '-'}
+          </AppText>
+          <AppText className="w-16 text-sm text-foreground text-center font-medium">
+            {p.percentLost !== null ? `${p.percentLost.toFixed(1)}%` : '-'}
+          </AppText>
+          <AppText className="w-12 text-sm font-bold text-brand text-right">
+            {p.points !== null ? p.points : '-'}
+          </AppText>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/features/challenges/components/weight-loss-prediction-banner.tsx
+++ b/src/features/challenges/components/weight-loss-prediction-banner.tsx
@@ -1,0 +1,28 @@
+// Removed React import
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import type { WeightLossPrediction } from '../types/challenge.model';
+
+interface WeightLossPredictionBannerProps {
+  prediction: WeightLossPrediction;
+}
+
+export function WeightLossPredictionBanner({ prediction }: WeightLossPredictionBannerProps) {
+  return (
+    <View
+      className="p-4 rounded-xl items-center border"
+      style={{
+        backgroundColor: mflColors.brandLight,
+        borderColor: mflColors.brand,
+      }}
+    >
+      <AppText className="text-sm font-semibold" style={{ color: mflColors.brand }}>
+        If you maintain this weight, you'll earn {prediction.predictedPoints} pts!
+      </AppText>
+      <AppText className="text-xs mt-1" style={{ color: mflColors.brand }}>
+        Current Progress: {prediction.currentPercentLost.toFixed(1)}% lost
+      </AppText>
+    </View>
+  );
+}

--- a/src/features/challenges/components/weight-loss-prediction-banner.tsx
+++ b/src/features/challenges/components/weight-loss-prediction-banner.tsx
@@ -9,6 +9,8 @@ interface WeightLossPredictionBannerProps {
 }
 
 export function WeightLossPredictionBanner({ prediction }: WeightLossPredictionBannerProps) {
+  const hasLost = prediction.currentPercentLost > 0;
+
   return (
     <View
       className="p-4 rounded-xl items-center border"
@@ -18,11 +20,15 @@ export function WeightLossPredictionBanner({ prediction }: WeightLossPredictionB
       }}
     >
       <AppText className="text-sm font-semibold" style={{ color: mflColors.brand }}>
-        If you maintain this weight, you'll earn {prediction.predictedPoints} pts!
+        {hasLost
+          ? `If you maintain this weight, you'll earn ${prediction.predictedPoints} pts!`
+          : "Log your progress to see your prediction"}
       </AppText>
-      <AppText className="text-xs mt-1" style={{ color: mflColors.brand }}>
-        Current Progress: {prediction.currentPercentLost.toFixed(1)}% lost
-      </AppText>
+      {hasLost ? (
+        <AppText className="text-xs mt-1" style={{ color: mflColors.brand }}>
+          Current Progress: {prediction.currentPercentLost.toFixed(1)}% lost
+        </AppText>
+      ) : null}
     </View>
   );
 }

--- a/src/features/challenges/components/weight-loss-results.tsx
+++ b/src/features/challenges/components/weight-loss-results.tsx
@@ -1,0 +1,42 @@
+import { View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import type { WeightLossResult } from '../types/challenge.model';
+
+interface WeightLossResultsProps {
+  result: WeightLossResult;
+}
+
+export function WeightLossResults({ result }: WeightLossResultsProps) {
+  return (
+    <View className="gap-4">
+      <AppText className="text-sm font-semibold text-foreground uppercase">
+        Final Results
+      </AppText>
+      <View
+        className="p-4 rounded-xl border flex-row justify-between items-center bg-card border-border"
+      >
+        <View className="gap-1">
+          <AppText className="text-xs text-muted">Final Weight Loss</AppText>
+          <AppText className="text-lg font-bold text-foreground">
+            {result.finalPercentLost.toFixed(1)}%
+          </AppText>
+          {result.matchedTier ? (
+            <AppText className="text-xs text-brand">
+              Tier {result.matchedTier.thresholdPercent}% reached!
+            </AppText>
+          ) : (
+            <AppText className="text-xs text-muted">
+              No tier reached.
+            </AppText>
+          )}
+        </View>
+        <View className="items-end gap-1">
+          <AppText className="text-xs text-muted">Points Earned</AppText>
+          <AppText className="text-2xl font-bold text-brand">
+            +{result.finalPoints}
+          </AppText>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/features/challenges/components/weight-loss-tier-config.tsx
+++ b/src/features/challenges/components/weight-loss-tier-config.tsx
@@ -1,0 +1,136 @@
+// Removed React import
+import { View, Pressable, TextInput } from 'react-native';
+import Feather from '@expo/vector-icons/Feather';
+import { AppText } from '../../../components/app-text';
+import { mflColors } from '../../../constants/colors';
+import { Stepper } from '../../leagues/components/settings-form-fields';
+import type { WeightLossTier } from '../types/challenge.model';
+
+interface WeightLossTierConfigProps {
+  durationDays?: number;
+  onDurationChange: (days: number) => void;
+  tiers: WeightLossTier[];
+  onAddTier: () => void;
+  onRemoveTier: (index: number) => void;
+  onUpdateTier: (index: number, field: keyof WeightLossTier, value: number) => void;
+  isValid: boolean;
+}
+
+export function WeightLossTierConfig({
+  durationDays = 30,
+  onDurationChange,
+  tiers,
+  onAddTier,
+  onRemoveTier,
+  onUpdateTier,
+  isValid,
+}: WeightLossTierConfigProps) {
+  return (
+    <View className="gap-6 mt-4">
+      <View className="gap-2">
+        <AppText className="text-sm font-semibold text-foreground">Challenge Duration</AppText>
+        <AppText className="text-xs text-muted mb-2">
+          How many days does the challenge run for?
+        </AppText>
+        <Stepper
+          label="Duration"
+          value={durationDays}
+          onIncrement={() => onDurationChange(durationDays + 1)}
+          onDecrement={() => onDurationChange(Math.max(1, durationDays - 1))}
+          min={1}
+          max={365}
+          unit="days"
+        />
+      </View>
+
+      <View className="gap-4">
+        <View className="flex-row items-center justify-between">
+          <View className="flex-1">
+            <AppText className="text-sm font-semibold text-foreground">Reward Tiers</AppText>
+            <AppText className="text-xs text-muted mt-1">
+              Set point rewards for achieving % weight loss goals.
+            </AppText>
+          </View>
+          <Pressable
+            onPress={onAddTier}
+            className="w-8 h-8 rounded-full items-center justify-center bg-card border border-border"
+          >
+            <Feather name="plus" size={16} color={mflColors.text} />
+          </Pressable>
+        </View>
+
+        {!isValid && (
+          <AppText className="text-xs text-red-500 font-medium">
+            Thresholds must be in ascending order.
+          </AppText>
+        )}
+
+        {tiers.length === 0 ? (
+          <AppText className="text-xs text-muted text-center py-4 italic">
+            No tiers configured. Players won't earn points.
+          </AppText>
+        ) : (
+          <View className="gap-3">
+            {tiers.map((tier, index) => (
+              <View
+                key={index}
+                className="flex-row items-center gap-3 p-3 rounded-xl border border-border bg-card"
+              >
+                <View className="flex-1 gap-1">
+                  <AppText className="text-xs text-muted">Goal % Loss</AppText>
+                  <TextInput
+                    style={{
+                      borderWidth: 1,
+                      borderColor: mflColors.border,
+                      borderRadius: 8,
+                      padding: 8,
+                      color: mflColors.text,
+                      fontSize: 14,
+                    }}
+                    value={tier.thresholdPercent.toString()}
+                    onChangeText={(v) => {
+                      const num = Number.parseInt(v, 10);
+                      if (!Number.isNaN(num)) {
+                        onUpdateTier(index, 'thresholdPercent', num);
+                      }
+                    }}
+                    keyboardType="numeric"
+                  />
+                </View>
+
+                <View className="flex-1 gap-1">
+                  <AppText className="text-xs text-muted">Points</AppText>
+                  <TextInput
+                    style={{
+                      borderWidth: 1,
+                      borderColor: mflColors.border,
+                      borderRadius: 8,
+                      padding: 8,
+                      color: mflColors.text,
+                      fontSize: 14,
+                    }}
+                    value={tier.points.toString()}
+                    onChangeText={(v) => {
+                      const num = Number.parseInt(v, 10);
+                      if (!Number.isNaN(num)) {
+                        onUpdateTier(index, 'points', num);
+                      }
+                    }}
+                    keyboardType="numeric"
+                  />
+                </View>
+
+                <Pressable
+                  onPress={() => onRemoveTier(index)}
+                  className="w-8 h-8 items-center justify-center mt-5"
+                >
+                  <Feather name="trash-2" size={18} color={mflColors.textMuted} />
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/src/features/challenges/hooks/use-weight-loss-log.ts
+++ b/src/features/challenges/hooks/use-weight-loss-log.ts
@@ -20,17 +20,19 @@ export function useWeightLossLogPlayer(leagueId: string, challengeId: string) {
       const res = await fetchWeightLossLogPlayer(leagueId, challengeId);
       return toWeightLogPlayerResponse(res);
     },
+    enabled: !!leagueId && !!challengeId,
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 }
 
-export function useWeightLossLogHost(leagueId: string, challengeId: string) {
+export function useWeightLossLogHost(leagueId: string, challengeId: string, enabled: boolean) {
   return useQuery<WeightLogHostParticipant[], Error>({
     queryKey: ['weight-loss-log-host', leagueId, challengeId],
     queryFn: async () => {
       const res = await fetchWeightLossLogHost(leagueId, challengeId);
       return (res.data || []).map(toWeightLogHostParticipant);
     },
+    enabled,
     staleTime: 1000 * 60 * 5,
   });
 }

--- a/src/features/challenges/hooks/use-weight-loss-log.ts
+++ b/src/features/challenges/hooks/use-weight-loss-log.ts
@@ -1,0 +1,54 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchWeightLossLogPlayer,
+  fetchWeightLossLogHost,
+  submitWeightLog,
+} from '../services/challenge.service';
+import {
+  toWeightLogPlayerResponse,
+  toWeightLogHostParticipant,
+} from '../mappers/challenge.mapper';
+import type {
+  WeightLogPlayerResponse,
+  WeightLogHostParticipant,
+} from '../types/challenge.model';
+
+export function useWeightLossLogPlayer(leagueId: string, challengeId: string) {
+  return useQuery<WeightLogPlayerResponse, Error>({
+    queryKey: ['weight-loss-log-player', leagueId, challengeId],
+    queryFn: async () => {
+      const res = await fetchWeightLossLogPlayer(leagueId, challengeId);
+      return toWeightLogPlayerResponse(res);
+    },
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+}
+
+export function useWeightLossLogHost(leagueId: string, challengeId: string) {
+  return useQuery<WeightLogHostParticipant[], Error>({
+    queryKey: ['weight-loss-log-host', leagueId, challengeId],
+    queryFn: async () => {
+      const res = await fetchWeightLossLogHost(leagueId, challengeId);
+      return (res.data || []).map(toWeightLogHostParticipant);
+    },
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useSubmitWeightLog(leagueId: string, challengeId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { logType: 'start' | 'progress' | 'end'; weight: number }) =>
+      submitWeightLog(leagueId, challengeId, data),
+    onSuccess: () => {
+      // Invalidate both player and host queries to ensure fresh data
+      void queryClient.invalidateQueries({
+        queryKey: ['weight-loss-log-player', leagueId, challengeId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['weight-loss-log-host', leagueId, challengeId],
+      });
+    },
+  });
+}

--- a/src/features/challenges/hooks/use-weight-loss-tiers.ts
+++ b/src/features/challenges/hooks/use-weight-loss-tiers.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import type { WeightLossTier } from '../types/challenge.model';
+
+export function useWeightLossTiers(initialTiers: WeightLossTier[] = []) {
+  const [tiers, setTiers] = useState<WeightLossTier[]>(initialTiers);
+
+  const addTier = useCallback(() => {
+    setTiers((prev) => {
+      const highestThreshold =
+        prev.length > 0 ? Math.max(...prev.map((t) => t.thresholdPercent)) : 0;
+      return [...prev, { thresholdPercent: highestThreshold + 1, points: 0 }];
+    });
+  }, []);
+
+  const removeTier = useCallback((index: number) => {
+    setTiers((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const updateTier = useCallback((index: number, field: keyof WeightLossTier, value: number) => {
+    setTiers((prev) => {
+      const updated = [...prev];
+      const target = updated[index];
+      if (!target) return prev;
+      
+      updated[index] = {
+        thresholdPercent: field === 'thresholdPercent' ? value : target.thresholdPercent,
+        points: field === 'points' ? value : target.points,
+      };
+      return updated;
+    });
+  }, []);
+
+  const validateTiers = useCallback(() => {
+    if (tiers.length === 0) return true;
+    for (let i = 1; i < tiers.length; i++) {
+      const current = tiers[i];
+      const prev = tiers[i - 1];
+      if (current && prev && current.thresholdPercent <= prev.thresholdPercent) {
+        return false;
+      }
+    }
+    return true;
+  }, [tiers]);
+
+  return {
+    tiers,
+    addTier,
+    removeTier,
+    updateTier,
+    validateTiers,
+  };
+}

--- a/src/features/challenges/mappers/challenge.mapper.ts
+++ b/src/features/challenges/mappers/challenge.mapper.ts
@@ -6,6 +6,7 @@ import type {
   WeightLogPlayerResponseDTO,
   WeightLogHostParticipantDTO,
   WeightLossTierDTO,
+  WeightLossConfigDTO,
 } from '../types/challenge.dto';
 import type {
   Challenge,
@@ -15,6 +16,7 @@ import type {
   WeightLogPlayerResponse,
   WeightLogHostParticipant,
   WeightLossTier,
+  WeightLossConfig,
 } from '../types/challenge.model';
 
 export function toChallenge(dto: ChallengeDTO): Challenge {
@@ -32,7 +34,7 @@ export function toChallenge(dto: ChallengeDTO): Challenge {
     startDate: dto.start_date,
     endDate: dto.end_date,
     status: dto.status,
-    config: dto.config,
+    config: toWeightLossConfig(dto.config),
     mySubmission: dto.my_submission,
     stats: dto.stats,
   };
@@ -71,6 +73,17 @@ export function toChallengePreset(dto: ChallengePresetDTO): ChallengePreset {
     description: dto.description,
     docUrl: dto.doc_url,
     challengeType: dto.challenge_type,
+  };
+}
+
+export function toWeightLossConfig(dto: WeightLossConfigDTO | null | undefined): WeightLossConfig | null {
+  if (!dto) return null;
+  return {
+    durationDays: dto.duration_days,
+    tiers: dto.tiers?.map((tier) => ({
+      thresholdPercent: tier.threshold_percent,
+      points: tier.points,
+    })),
   };
 }
 

--- a/src/features/challenges/mappers/challenge.mapper.ts
+++ b/src/features/challenges/mappers/challenge.mapper.ts
@@ -3,12 +3,18 @@ import type {
   ChallengeSubmissionDTO,
   ChallengeLeaderboardEntryDTO,
   ChallengePresetDTO,
+  WeightLogPlayerResponseDTO,
+  WeightLogHostParticipantDTO,
+  WeightLossTierDTO,
 } from '../types/challenge.dto';
 import type {
   Challenge,
   ChallengeSubmission,
   ChallengeLeaderboardEntry,
   ChallengePreset,
+  WeightLogPlayerResponse,
+  WeightLogHostParticipant,
+  WeightLossTier,
 } from '../types/challenge.model';
 
 export function toChallenge(dto: ChallengeDTO): Challenge {
@@ -26,6 +32,7 @@ export function toChallenge(dto: ChallengeDTO): Challenge {
     startDate: dto.start_date,
     endDate: dto.end_date,
     status: dto.status,
+    config: dto.config,
     mySubmission: dto.my_submission,
     stats: dto.stats,
   };
@@ -64,5 +71,50 @@ export function toChallengePreset(dto: ChallengePresetDTO): ChallengePreset {
     description: dto.description,
     docUrl: dto.doc_url,
     challengeType: dto.challenge_type,
+  };
+}
+
+export function toWeightLossTier(dto: WeightLossTierDTO | null | undefined): WeightLossTier | null {
+  if (!dto) return null;
+  return {
+    thresholdPercent: dto.threshold_percent,
+    points: dto.points,
+  };
+}
+
+export function toWeightLogPlayerResponse(dto: WeightLogPlayerResponseDTO): WeightLogPlayerResponse {
+  return {
+    logs: (dto.data?.logs ?? []).map((log) => ({
+      id: log.id,
+      leagueMemberId: log.league_member_id,
+      weight: log.weight,
+      logType: log.log_type,
+      createdAt: log.created_at,
+    })),
+    prediction: dto.data?.prediction
+      ? {
+          predictedPoints: dto.data.prediction.predicted_points,
+          currentPercentLost: dto.data.prediction.current_percent_lost,
+          matchedTier: toWeightLossTier(dto.data.prediction.matched_tier),
+        }
+      : null,
+    result: dto.data?.result
+      ? {
+          finalPoints: dto.data.result.final_points,
+          finalPercentLost: dto.data.result.final_percent_lost,
+          matchedTier: toWeightLossTier(dto.data.result.matched_tier),
+        }
+      : null,
+  };
+}
+
+export function toWeightLogHostParticipant(dto: WeightLogHostParticipantDTO): WeightLogHostParticipant {
+  return {
+    leagueMemberId: dto.league_member_id,
+    username: dto.username,
+    startWeight: dto.start_weight,
+    endWeight: dto.end_weight,
+    percentLost: dto.percent_lost,
+    points: dto.points,
   };
 }

--- a/src/features/challenges/services/challenge-fetch.service.ts
+++ b/src/features/challenges/services/challenge-fetch.service.ts
@@ -3,6 +3,8 @@ import type {
   ChallengesResponseDTO,
   ChallengeSubmissionsResponseDTO,
   ChallengeLeaderboardResponseDTO,
+  WeightLogPlayerResponseDTO,
+  WeightLogHostResponseDTO,
 } from '../types/challenge.dto';
 import type {
   ChallengeSubTeamDetails,
@@ -179,4 +181,25 @@ export async function fetchTournamentScores(
     teamId: score.team_id,
     score: Number(score.score ?? 0),
   }));
+}
+
+export async function fetchWeightLossLogPlayer(
+  leagueId: string,
+  challengeId: string,
+): Promise<WeightLogPlayerResponseDTO> {
+  const res = await api.get<WeightLogPlayerResponseDTO>(
+    `/api/leagues/${leagueId}/challenges/${challengeId}/weight-log`,
+  );
+  return res.data;
+}
+
+export async function fetchWeightLossLogHost(
+  leagueId: string,
+  challengeId: string,
+): Promise<WeightLogHostResponseDTO> {
+  const res = await api.get<WeightLogHostResponseDTO>(
+    `/api/leagues/${leagueId}/challenges/${challengeId}/weight-log`,
+    { params: { view: 'host' } } // TODO(weight-loss-api): confirm if 'view=host' is the right way to request host data
+  );
+  return res.data;
 }

--- a/src/features/challenges/services/challenge-mutation.service.ts
+++ b/src/features/challenges/services/challenge-mutation.service.ts
@@ -224,3 +224,18 @@ export async function finalizeTournamentScores(
   );
   return res.data;
 }
+
+export async function submitWeightLog(
+  leagueId: string,
+  challengeId: string,
+  data: { logType: 'start' | 'progress' | 'end'; weight: number },
+): Promise<MutateChallengeResponseDTO> {
+  const res = await api.post<MutateChallengeResponseDTO>(
+    `/api/leagues/${leagueId}/challenges/${challengeId}/weight-log`,
+    {
+      log_type: data.logType,
+      weight: data.weight,
+    } // TODO(weight-loss-api): confirm against live endpoint for request body structure
+  );
+  return res.data;
+}

--- a/src/features/challenges/services/challenge.service.ts
+++ b/src/features/challenges/services/challenge.service.ts
@@ -20,6 +20,8 @@ export {
   fetchTournamentMatches,
   fetchTournamentScores,
   toTournamentMatch,
+  fetchWeightLossLogPlayer,
+  fetchWeightLossLogHost,
 } from './challenge-fetch.service';
 
 export type { TournamentMatchRow } from './challenge-fetch.service';
@@ -39,6 +41,7 @@ export {
   updateTournamentMatch,
   deleteTournamentMatch,
   finalizeTournamentScores,
+  submitWeightLog,
 } from './challenge-mutation.service';
 
 export type { ChallengeMutationInput } from './challenge-mutation.service';

--- a/src/features/challenges/types/challenge-config.ts
+++ b/src/features/challenges/types/challenge-config.ts
@@ -1,4 +1,4 @@
-import type { ChallengeType } from './challenge.model';
+import type { ChallengeType, WeightLossConfig } from './challenge.model';
 
 export interface ChallengeConfigForm {
   name: string;
@@ -9,7 +9,7 @@ export interface ChallengeConfigForm {
   startDate: string;
   endDate: string;
   isUniqueWorkout: boolean;
-  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
+  config?: WeightLossConfig | null; // TODO(weight-loss-api): confirm against live endpoint
 }
 
 export const EMPTY_CHALLENGE_FORM: ChallengeConfigForm = {

--- a/src/features/challenges/types/challenge-config.ts
+++ b/src/features/challenges/types/challenge-config.ts
@@ -9,6 +9,7 @@ export interface ChallengeConfigForm {
   startDate: string;
   endDate: string;
   isUniqueWorkout: boolean;
+  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
 }
 
 export const EMPTY_CHALLENGE_FORM: ChallengeConfigForm = {
@@ -20,6 +21,7 @@ export const EMPTY_CHALLENGE_FORM: ChallengeConfigForm = {
   startDate: '',
   endDate: '',
   isUniqueWorkout: false,
+  config: null,
 };
 
 export interface PickedChallengeDocument {

--- a/src/features/challenges/types/challenge.dto.ts
+++ b/src/features/challenges/types/challenge.dto.ts
@@ -24,7 +24,7 @@ export interface ChallengeDTO {
   end_date: string | null;
   status: ChallengeStatusDTO;
   template_id: string | null;
-  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
+  config?: WeightLossConfigDTO | null; // TODO(weight-loss-api): confirm against live endpoint
   my_submission: any | null;
   stats: { pending: number; approved: number; rejected: number } | null;
 }

--- a/src/features/challenges/types/challenge.dto.ts
+++ b/src/features/challenges/types/challenge.dto.ts
@@ -1,4 +1,4 @@
-export type ChallengeTypeDTO = 'individual' | 'team' | 'sub_team' | 'tournament';
+export type ChallengeTypeDTO = 'individual' | 'team' | 'sub_team' | 'tournament' | 'weight_loss';
 export type ChallengeStatusDTO =
   | 'draft'
   | 'scheduled'
@@ -24,6 +24,7 @@ export interface ChallengeDTO {
   end_date: string | null;
   status: ChallengeStatusDTO;
   template_id: string | null;
+  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
   my_submission: any | null;
   stats: { pending: number; approved: number; rejected: number } | null;
 }
@@ -110,4 +111,59 @@ export interface UploadChallengeProofResponseDTO {
     path: string;
     bucket: string;
   };
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossTierDTO {
+  threshold_percent: number;
+  points: number;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossConfigDTO {
+  duration_days?: number;
+  tiers?: WeightLossTierDTO[];
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogEntryDTO {
+  id: string;
+  league_member_id: string;
+  weight: number;
+  log_type: 'start' | 'progress' | 'end';
+  created_at: string;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogPlayerResponseDTO {
+  success: boolean;
+  data: {
+    logs: WeightLogEntryDTO[];
+    prediction: {
+      predicted_points: number;
+      current_percent_lost: number;
+      matched_tier: WeightLossTierDTO | null;
+    } | null;
+    result: {
+      final_points: number;
+      final_percent_lost: number;
+      matched_tier: WeightLossTierDTO | null;
+    } | null;
+  };
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogHostParticipantDTO {
+  league_member_id: string;
+  username: string;
+  start_weight: number | null;
+  end_weight: number | null;
+  percent_lost: number | null;
+  points: number | null;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogHostResponseDTO {
+  success: boolean;
+  data: WeightLogHostParticipantDTO[];
 }

--- a/src/features/challenges/types/challenge.model.ts
+++ b/src/features/challenges/types/challenge.model.ts
@@ -1,4 +1,4 @@
-export type ChallengeType = 'individual' | 'team' | 'sub_team' | 'tournament';
+export type ChallengeType = 'individual' | 'team' | 'sub_team' | 'tournament' | 'weight_loss';
 export type ChallengeStatus =
   | 'draft'
   | 'scheduled'
@@ -21,6 +21,7 @@ export interface Challenge {
   startDate: string | null;
   endDate: string | null;
   status: ChallengeStatus;
+  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
   mySubmission: any | null;
   stats: { pending: number; approved: number; rejected: number } | null;
 }
@@ -117,4 +118,56 @@ export interface TournamentMatchInput {
 export interface TournamentScore {
   teamId: string;
   score: number;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossTier {
+  thresholdPercent: number;
+  points: number;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossConfig {
+  durationDays?: number;
+  tiers?: WeightLossTier[];
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogEntry {
+  id: string;
+  leagueMemberId: string;
+  weight: number;
+  logType: 'start' | 'progress' | 'end';
+  createdAt: string;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossPrediction {
+  predictedPoints: number;
+  currentPercentLost: number;
+  matchedTier: WeightLossTier | null;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLossResult {
+  finalPoints: number;
+  finalPercentLost: number;
+  matchedTier: WeightLossTier | null;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogPlayerResponse {
+  logs: WeightLogEntry[];
+  prediction: WeightLossPrediction | null;
+  result: WeightLossResult | null;
+}
+
+// TODO(weight-loss-api): confirm against live endpoint
+export interface WeightLogHostParticipant {
+  leagueMemberId: string;
+  username: string;
+  startWeight: number | null;
+  endWeight: number | null;
+  percentLost: number | null;
+  points: number | null;
 }

--- a/src/features/challenges/types/challenge.model.ts
+++ b/src/features/challenges/types/challenge.model.ts
@@ -21,7 +21,7 @@ export interface Challenge {
   startDate: string | null;
   endDate: string | null;
   status: ChallengeStatus;
-  config?: any | null; // TODO(weight-loss-api): confirm against live endpoint
+  config?: WeightLossConfig | null; // TODO(weight-loss-api): confirm against live endpoint
   mySubmission: any | null;
   stats: { pending: number; approved: number; rejected: number } | null;
 }

--- a/src/features/challenges/utils/challenge-config-utils.ts
+++ b/src/features/challenges/utils/challenge-config-utils.ts
@@ -22,6 +22,11 @@ export const CHALLENGE_TYPES: Array<{ value: ChallengeType; label: string; descr
     label: 'Tournament',
     description: 'Bracket-style tournament with fixtures and standings.',
   },
+  {
+    value: 'weight_loss',
+    label: 'Weight Loss',
+    description: 'Track weight loss over time. Earn points by hitting % loss tiers.',
+  },
 ];
 
 export function formatChallengeType(type: ChallengeType | string): string {
@@ -83,6 +88,7 @@ export function getStatusColors(status: ChallengeStatus): { color: string; bgCol
 
 export function isReviewEnabled(type: ChallengeType, status: ChallengeStatus): boolean {
   if (type === 'team') return status !== 'draft';
+  if (type === 'weight_loss') return false;
   return status === 'submission_closed' || status === 'published';
 }
 
@@ -92,6 +98,7 @@ export function canPublishChallenge(
   pendingCount: number,
 ): boolean {
   if (type === 'tournament') return false;
+  if (type === 'weight_loss') return status !== 'draft' && status !== 'published';
   if (type === 'team') return status !== 'draft' && status !== 'published';
   return status === 'submission_closed' && pendingCount === 0;
 }

--- a/src/features/challenges/utils/challenge-helpers.ts
+++ b/src/features/challenges/utils/challenge-helpers.ts
@@ -10,6 +10,8 @@ export function getChallengeTypeLabel(type: ChallengeType): string {
       return 'Sub-Team Challenge';
     case 'tournament':
       return 'Tournament';
+    case 'weight_loss':
+      return 'Weight Loss Challenge';
     default:
       return type;
   }
@@ -75,6 +77,7 @@ export function canSubmitChallenge(
 ): boolean {
   if (status !== 'active') return false;
   if (challengeType === 'tournament') return false;
+  if (challengeType === 'weight_loss') return false;
 
   // No submission yet — can submit
   if (!mySubmission) return true;

--- a/src/features/leagues/components/settings-form-fields.tsx
+++ b/src/features/leagues/components/settings-form-fields.tsx
@@ -77,6 +77,7 @@ export function Stepper({
   min,
   max,
   disabled,
+  unit,
 }: {
   label: string;
   description?: string;
@@ -86,6 +87,7 @@ export function Stepper({
   min: number;
   max: number;
   disabled?: boolean;
+  unit?: string;
 }) {
   return (
     <View className="flex-row items-center justify-between py-3" style={{ opacity: disabled ? 0.5 : 1 }}>
@@ -107,7 +109,7 @@ export function Stepper({
           <Feather name="minus" size={18} color={value <= min ? mflColors.textMuted : mflColors.brand} />
         </Pressable>
         <AppText className="text-lg font-bold text-foreground" style={{ minWidth: 32, textAlign: 'center' }}>
-          {value}
+          {value}{unit ? ` ${unit}` : ''}
         </AppText>
         <Pressable
           onPress={onIncrement}


### PR DESCRIPTION
Partial fix for #134 

## Summary
Mobile parity for the Weight Loss Challenge feature (web: adminmfl/mfl#521). Adds the `weight_loss` challenge type end-to-end: types/DTOs, query/mutation hooks, player weight logging + prediction + results UI, host tier config + results UI, routing, and submission eligibility updates.

## Changes
- Types: `'weight_loss'` added to `ChallengeTypeDTO`/`ChallengeType`, new DTOs/models for config, tiers, logs, predictions, results
- Services/hooks: `fetchWeightLossLogPlayer`, `fetchWeightLossLogHost`, `submitWeightLog`, `use-weight-loss-log.ts`, `use-weight-loss-tiers.ts`
- Player UI: weight logging screen, prediction banner, results screen
- Host UI: tier config (duration + thresholds + points), participant results table
- Routing: `weight-log.tsx`, `canSubmitChallenge` updated to exclude `weight_loss` (routes to standalone logger instead)

## Pending / inferred
Several API request/response shapes (`WeightLossConfigDTO`, weight-log GET/POST contracts) were inferred against the web PR since the live endpoint shapes weren't accessible at implementation time. Fields are marked `// TODO(weight-loss-api): confirm against live endpoint` — search for that string to find them. Will reconcile once confirmed.

## Testing
`npx tsc --noEmit` passes for all files touched by this PR. 